### PR TITLE
Feature addtag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -140,11 +140,19 @@ public class AddTagCommand extends Command {
         CommandResult editPersonResult = (new EditCommand(index, editPersonDescriptor)).executeNoRefresh(model);
         LOGGER.info(editPersonResult.getFeedbackToUser());
 
-        String indexStr = this.index == null ? "all" : String.valueOf(index.getOneBased());
-        return new CommandResult(String.format(MESSAGE_SINGLE_ADD_TAGS_SUCCESS, toBeAddedTagsStr, indexStr));
+        assert index != null : "[AddTagCommand] Index in executeSingle should not be null";
+        return new CommandResult(String.format(
+                MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                toBeAddedTagsStr,
+                personToEdit.getName()));
     }
 
-    private static String tagSetToSting(Set<Tag> tags) {
+    /**
+     * Formats the tag set to be more user friendly string.
+     * @param tags set to be formatted.
+     * @return the fomatted list of tags/
+     */
+    public static String tagSetToSting(Set<Tag> tags) {
         String res = "";
         for (Tag tag : tags) {
             res += tag.toString() + ", ";

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -1,16 +1,58 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
+import seedu.address.model.tag.Tag;
 
 /**
- * Changes the remark of an existing person in the address book.
+ * Add tag for an existing person in the address book.
  */
 public class AddTagCommand extends Command {
 
     public static final String COMMAND_WORD = "addtag";
 
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$s, new tag: %2$s";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add tags for a person in the address book.\n"
+        + "Parameters:\n"
+        + "  INDEX (must be a positive integer or use \"all\" to add tags for everyone in the list) \n"
+        + "  [" + PREFIX_TAG + "TAG]...\n"
+        + "Example:\n" + COMMAND_WORD + " 1 "
+        + PREFIX_TAG + "lab "
+        + PREFIX_TAG + "goodProgress"
+        + "\nor\n" + COMMAND_WORD + " all "
+        + PREFIX_TAG + "tutorial "
+        + PREFIX_TAG + "needRemedial";
+
+    /** 
+     * Index of the person to add the tags for. 
+     * If index is null, the tags will be added for every person in the list.
+     */
+    private Index index;
+    
+    /** The tags to be added. */
+    private Set<Tag> tags;
+
+    /**
+     * @param index of the person in the filtered person list to add the tag
+     * @param tags of the person to be added
+     */
+    public AddTagCommand(Index index, Set<Tag> tags) {
+        requireNonNull(tags);
+
+        this.index = index;
+        this.tags = tags;
+    }
+
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult("Placeholder for addtag");
+        String indexStr = this.index == null ? "all" : String.valueOf(index.getOneBased());
+        return new CommandResult(String.format(MESSAGE_ARGUMENTS, indexStr, this.tags));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -1,0 +1,16 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Changes the remark of an existing person in the address book.
+ */
+public class AddTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "addtag";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult("Placeholder for addtag");
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -1,19 +1,28 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 
+import seedu.address.MainApp;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
 /**
  * Add tag for an existing person in the address book.
  */
 public class AddTagCommand extends Command {
+
+    public static final Logger LOGGER = LogsCenter.getLogger(MainApp.class);
 
     public static final String COMMAND_WORD = "addtag";
 
@@ -30,13 +39,19 @@ public class AddTagCommand extends Command {
         + PREFIX_TAG + "tutorial "
         + PREFIX_TAG + "needRemedial";
 
-    /** 
-     * Index of the person to add the tags for. 
+    public static final String MESSAGE_ADD_TAGS_SUCCESS = "Added tags %1$s Person: %2$s";
+
+    public static final String MESSAGE_TAGS_NOT_ADDED = "At least one tag must be added";
+
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+
+    /**
+     * Index of the person to add the tags for.
      * If index is null, the tags will be added for every person in the list.
      */
     private Index index;
-    
-    /** The tags to be added. */
+
+    /** The tags to be added.*/
     private Set<Tag> tags;
 
     /**
@@ -51,8 +66,27 @@ public class AddTagCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Set<Tag> existingTags = personToEdit.getTags();
+        for (Tag tag : existingTags) {
+            if (!this.tags.contains(tag)) {
+                this.tags.add(tag);
+            }
+        }
+        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+        editPersonDescriptor.setTags(this.tags);
+        LOGGER.info((new EditCommand(index, editPersonDescriptor)).execute(model).getFeedbackToUser());
+
+
         String indexStr = this.index == null ? "all" : String.valueOf(index.getOneBased());
-        return new CommandResult(String.format(MESSAGE_ARGUMENTS, indexStr, this.tags));
+        return new CommandResult(String.format(MESSAGE_ADD_TAGS_SUCCESS, this.tags.toString(), indexStr));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -93,7 +93,6 @@ public class AddTagCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-    
         if (this.isAddToAll) {
             int numOfPersonUpdated = 0;
             for (int idx = 0; idx < lastShownList.size(); idx++) {
@@ -103,16 +102,16 @@ public class AddTagCommand extends Command {
             }
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             return new CommandResult(String.format(
-                    MESSAGE_MULTI_ADD_TAGS_SUCCESS, 
-                    toBeAddedTagsStr, 
+                    MESSAGE_MULTI_ADD_TAGS_SUCCESS,
+                    toBeAddedTagsStr,
                     numOfPersonUpdated));
-        } 
+        }
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        assert !this.isAddToAll && this.index != null 
+        assert !this.isAddToAll && this.index != null
                 : "[AddTagCommand] index should not be null if it is not all";
         Person personToEdit = lastShownList.get(index.getZeroBased());
         CommandResult res = executeSingle(model, this.index, personToEdit);
@@ -129,7 +128,7 @@ public class AddTagCommand extends Command {
      * @throws CommandException If an error occurs during command execution.
      */
     public CommandResult executeSingle(
-                Model model, Index index, Person personToEdit) throws CommandException{
+                Model model, Index index, Person personToEdit) throws CommandException {
         Set<Tag> existingTags = personToEdit.getTags();
         for (Tag tag : existingTags) {
             if (!this.tags.contains(tag)) {
@@ -151,8 +150,7 @@ public class AddTagCommand extends Command {
             res += tag.toString() + ", ";
         }
         return res.substring(0, res.length() - 2);
-    } 
-    
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -86,6 +86,25 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 
+    public CommandResult executeNoRefresh(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+
+        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.setPerson(personToEdit, editedPerson);
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+    }
+
     /**
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -86,6 +86,12 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 
+    /**
+     * Edits the person without returning to the full persons list.
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display.
+     * @throws CommandException If an error occurs during command execution.
+     */
     public CommandResult executeNoRefresh(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -15,25 +14,33 @@ import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
+/**
+ * Parses input arguments and creates a new AddTagCommand object
+ */
 public class AddTagCommandParser implements Parser<AddTagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddTagCommand
+     * and returns an AddTagCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public AddTagCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_TAG);
-    
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+
         Index index;
         Set<Tag> tags;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
             tags = parseTagsSet(argMultimap.getAllValues(PREFIX_TAG));
             if (tags.size() == 0) {
-                throw new IllegalValueException("Tags cannot be empty for addtag");
+                throw new ParseException(AddTagCommand.MESSAGE_TAGS_NOT_ADDED);
             }
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddTagCommand.MESSAGE_USAGE), ive);
         }
-    
+
         return new AddTagCommand(index, tags);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -31,11 +31,14 @@ public class AddTagCommandParser implements Parser<AddTagCommand> {
         Index index;
         Set<Tag> tags;
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
             tags = parseTagsSet(argMultimap.getAllValues(PREFIX_TAG));
             if (tags.size() == 0) {
                 throw new ParseException(AddTagCommand.MESSAGE_TAGS_NOT_ADDED);
             }
+            if (argMultimap.getPreamble().equalsIgnoreCase("all")) {
+                return new AddTagCommand(tags);
+            }
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddTagCommand.MESSAGE_USAGE), ive);

--- a/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTagCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+public class AddTagCommandParser implements Parser<AddTagCommand> {
+    public AddTagCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_TAG);
+    
+        Index index;
+        Set<Tag> tags;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            tags = parseTagsSet(argMultimap.getAllValues(PREFIX_TAG));
+            if (tags.size() == 0) {
+                throw new IllegalValueException("Tags cannot be empty for addtag");
+            }
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddTagCommand.MESSAGE_USAGE), ive);
+        }
+    
+        return new AddTagCommand(index, tags);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Set<Tag> parseTagsSet(Collection<String> tags) throws ParseException {
+        assert tags != null && !tags.isEmpty();
+
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return ParserUtil.parseTags(tagSet);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case AddTagCommand.COMMAND_WORD:
+            return new AddTagCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -64,7 +64,7 @@ public class AddressBookParser {
             return new ListCommand();
 
         case AddTagCommand.COMMAND_WORD:
-            return new AddTagCommand();
+            return new AddTagCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
@@ -1,0 +1,301 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_STUDENT;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * EditCommand.
+ */
+public class AddTagCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Set<Tag> singleTagSet = Stream.of(VALID_TAG_FRIEND).map(Tag::new).collect(Collectors.toSet());
+    private Set<Tag> multiTagSet = Stream.of(VALID_TAG_FRIEND, VALID_TAG_STUDENT).map(Tag::new)
+            .collect(Collectors.toSet());
+    private Set<Tag> multiTagSetReversed = Stream.of(VALID_TAG_STUDENT, VALID_TAG_FRIEND).map(Tag::new)
+            .collect(Collectors.toSet());
+
+    @Test
+    public void execute_addSingleTagUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPersonBase = personInList.withTags(VALID_TAG_HUSBAND).build();
+        Person editedPersonExpected = personInList.withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        baseModel.setPerson(lastPerson, editedPersonBase);
+        AddTagCommand addTagCommand = new AddTagCommand(indexLastPerson, singleTagSet);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPersonExpected);
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(singleTagSet),
+                editedPersonBase.getName());
+
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addMultiTagUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPersonBase = personInList.withTags(VALID_TAG_HUSBAND).build();
+        Person editedPersonExpected = personInList.withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND, VALID_TAG_STUDENT)
+                .build();
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        baseModel.setPerson(lastPerson, editedPersonBase);
+        AddTagCommand addTagCommand = new AddTagCommand(indexLastPerson, multiTagSet);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPersonExpected);
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(multiTagSet),
+                editedPersonBase.getName());
+
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addSingleTagAllUnfilteredList_success() {
+        PersonBuilder personInList;
+        Person editedPersonBase;
+        Person editedPersonExpected;
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_MULTI_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(singleTagSet),
+                model.getFilteredPersonList().size());
+
+        for (Person person : model.getFilteredPersonList()) {
+            personInList = new PersonBuilder(person);
+            editedPersonBase = personInList.withTags(VALID_TAG_HUSBAND).build();
+            baseModel.setPerson(person, editedPersonBase);
+            editedPersonExpected = personInList.withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            expectedModel.setPerson(person, editedPersonExpected);
+        }
+
+        AddTagCommand addTagCommand = new AddTagCommand(singleTagSet);
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addMultiTagAllUnfilteredList_success() {
+        PersonBuilder personInList;
+        Person editedPersonBase;
+        Person editedPersonExpected;
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_MULTI_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(multiTagSet),
+                model.getFilteredPersonList().size());
+
+        for (Person person : model.getFilteredPersonList()) {
+            personInList = new PersonBuilder(person);
+            editedPersonBase = personInList.withTags(VALID_TAG_HUSBAND).build();
+            baseModel.setPerson(person, editedPersonBase);
+            editedPersonExpected = personInList.withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND, VALID_TAG_STUDENT)
+                    .build();
+            expectedModel.setPerson(person, editedPersonExpected);
+        }
+
+        AddTagCommand addTagCommand = new AddTagCommand(multiTagSet);
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addDuplicateTagUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPersonBase = personInList.withTags(VALID_TAG_FRIEND).build();
+        Person editedPersonModel = personInList.withTags(VALID_TAG_FRIEND, VALID_TAG_STUDENT).build();
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        baseModel.setPerson(lastPerson, editedPersonBase);
+        AddTagCommand addTagCommand = new AddTagCommand(indexLastPerson, multiTagSet);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPersonModel);
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(multiTagSet),
+                editedPersonBase.getName());
+
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addToNewSingleTagUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPersonBase = personInList.withTags().build();
+        Person editedPersonModel = personInList.withTags(VALID_TAG_FRIEND).build();
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        baseModel.setPerson(lastPerson, editedPersonBase);
+        AddTagCommand addTagCommand = new AddTagCommand(indexLastPerson, singleTagSet);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPersonModel);
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(singleTagSet),
+                editedPersonBase.getName());
+
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addSingleTagAllFilteredList_success() {
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+        PersonBuilder personInList;
+        Person editedPersonBase;
+        Person editedPersonExpected;
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_MULTI_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(singleTagSet),
+                model.getFilteredPersonList().size());
+
+        for (Person person : model.getFilteredPersonList()) {
+            personInList = new PersonBuilder(person);
+            editedPersonBase = personInList.withTags(VALID_TAG_HUSBAND).build();
+            baseModel.setPerson(person, editedPersonBase);
+            editedPersonExpected = personInList.withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            expectedModel.setPerson(person, editedPersonExpected);
+        }
+
+        showPersonAtIndex(baseModel, INDEX_SECOND_PERSON);
+        AddTagCommand addTagCommand = new AddTagCommand(singleTagSet);
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_addMultiTagFilteredList_success() {
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPersonBase = personInList.withTags(VALID_TAG_HUSBAND).build();
+        Person editedPersonExpected = personInList.withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+
+        Model baseModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        baseModel.setPerson(lastPerson, editedPersonBase);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPersonExpected);
+        String expectedMessage = String.format(
+                AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToSting(singleTagSet),
+                editedPersonBase.getName());
+
+        showPersonAtIndex(baseModel, INDEX_SECOND_PERSON);
+        AddTagCommand addTagCommand = new AddTagCommand(indexLastPerson, singleTagSet);
+
+        assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, singleTagSet);
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, singleTagSet);
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AddTagCommand standardSingleCommand = new AddTagCommand(INDEX_FIRST_PERSON, singleTagSet);
+        final AddTagCommand standardMultiCommand = new AddTagCommand(INDEX_FIRST_PERSON, multiTagSetReversed);
+
+        // same values -> returns true
+        AddTagCommand commandWithSameValues = new AddTagCommand(INDEX_FIRST_PERSON, singleTagSet);
+        assertTrue(standardSingleCommand.equals(commandWithSameValues));
+
+        // same values but different order -> returns true
+        AddTagCommand commandWithSameMultiValues = new AddTagCommand(INDEX_FIRST_PERSON, multiTagSetReversed);
+        assertTrue(standardMultiCommand.equals(commandWithSameMultiValues));
+
+        // same object -> returns true
+        assertTrue(standardSingleCommand.equals(standardSingleCommand));
+
+        // null -> returns false
+        assertFalse(standardSingleCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardSingleCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardSingleCommand.equals(new AddTagCommand(INDEX_SECOND_PERSON, singleTagSet)));
+
+        // different descriptor -> returns false
+        assertFalse(standardSingleCommand.equals(new AddTagCommand(INDEX_FIRST_PERSON, multiTagSet)));
+    }
+
+    public static void main(String[] args) {
+        AddTagCommandTest test = new AddTagCommandTest();
+        test.execute_invalidPersonIndexFilteredList_failure();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -36,6 +36,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_STUDENT = "student";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;


### PR DESCRIPTION
## Implemented addtag for single index and `all` for mass ops. (Resolve #17)
 1. Internally append the tags to be added to existing tags for the person.
 2. Internally execute EditCommand to update the tag set.
 3. Log the result of EditCommand but do not show it to users.
 4. Success message shows index for single-index addtag but shows the number of persons edited for `addtag all`.

### Note:
- Add executeNoRefresh to EditCommand so that the filteredlist does not get return back to the unfiltered state after editing a single person (Critical for `addtag all`).
- Add tagSetToString to better display tagsets --> may want to extends to other uses of the tags or make it look nicer? 