### PR TITLE
Unify Edit Command

### DIFF
--- a/src/main/java/seedu/studmap/commons/core/Messages.java
+++ b/src/main/java/seedu/studmap/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
+    public static final String MESSAGE_DUPLICATE_STUDENT = "Student already exists!";
 
 }

--- a/src/main/java/seedu/studmap/commons/core/index/AllIndexGenerator.java
+++ b/src/main/java/seedu/studmap/commons/core/index/AllIndexGenerator.java
@@ -1,0 +1,34 @@
+package seedu.studmap.commons.core.index;
+
+import java.util.List;
+
+import seedu.studmap.model.Model;
+
+/**
+ * An IndexListGenerator that generates all the indices of filtered students.
+ */
+public class AllIndexGenerator extends IndexListGenerator {
+
+
+    @Override
+    public List<Index> apply(Model model) {
+        return model.getFilteredStudentIndices();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null) {
+            return false;
+        }
+
+        if (!(other instanceof AllIndexGenerator)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/seedu/studmap/commons/core/index/IndexListGenerator.java
+++ b/src/main/java/seedu/studmap/commons/core/index/IndexListGenerator.java
@@ -1,0 +1,21 @@
+package seedu.studmap.commons.core.index;
+
+import java.util.List;
+import java.util.function.Function;
+
+import seedu.studmap.model.Model;
+
+/**
+ * An abstract class for a functional interface that generates indices.
+ */
+public abstract class IndexListGenerator implements Function<Model, List<Index>> {
+    @Override
+    public <V> Function<V, List<Index>> compose(Function<? super V, ? extends Model> before) {
+        return Function.super.compose(before);
+    }
+
+    @Override
+    public <V> Function<Model, V> andThen(Function<? super List<Index>, ? extends V> after) {
+        return Function.super.andThen(after);
+    }
+}

--- a/src/main/java/seedu/studmap/commons/core/index/IndexListGenerator.java
+++ b/src/main/java/seedu/studmap/commons/core/index/IndexListGenerator.java
@@ -9,13 +9,4 @@ import seedu.studmap.model.Model;
  * An abstract class for a functional interface that generates indices.
  */
 public abstract class IndexListGenerator implements Function<Model, List<Index>> {
-    @Override
-    public <V> Function<V, List<Index>> compose(Function<? super V, ? extends Model> before) {
-        return Function.super.compose(before);
-    }
-
-    @Override
-    public <V> Function<Model, V> andThen(Function<? super List<Index>, ? extends V> after) {
-        return Function.super.andThen(after);
-    }
 }

--- a/src/main/java/seedu/studmap/commons/core/index/SingleIndexGenerator.java
+++ b/src/main/java/seedu/studmap/commons/core/index/SingleIndexGenerator.java
@@ -1,0 +1,40 @@
+package seedu.studmap.commons.core.index;
+
+import java.util.List;
+
+import seedu.studmap.model.Model;
+
+/**
+ * An IndexListGenerator that generates a list containing a single index.
+ */
+public class SingleIndexGenerator extends IndexListGenerator {
+
+    private Index index;
+
+    public SingleIndexGenerator(Index index) {
+        this.index = index;
+    }
+
+    @Override
+    public List<Index> apply(Model model) {
+        return List.of(index);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null) {
+            return false;
+        }
+
+        if (!(other instanceof SingleIndexGenerator)) {
+            return false;
+        }
+
+        SingleIndexGenerator e = (SingleIndexGenerator) other;
+        return this.index.equals(e.index);
+    }
+}

--- a/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
@@ -2,26 +2,27 @@ package seedu.studmap.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.studmap.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.logging.Logger;
 
 import seedu.studmap.MainApp;
 import seedu.studmap.commons.core.LogsCenter;
-import seedu.studmap.commons.core.Messages;
 import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.logic.commands.exceptions.CommandException;
+import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.student.Student;
+import seedu.studmap.model.student.StudentData;
 import seedu.studmap.model.tag.Tag;
 
 /**
  * Add tag for an existing student in the student map.
  */
-public class AddTagCommand extends Command {
+public class AddTagCommand extends EditStudentCommand<AddTagCommand.AddTagCommandStudentEditor> {
 
     public static final Logger LOGGER = LogsCenter.getLogger(MainApp.class);
 
@@ -30,15 +31,15 @@ public class AddTagCommand extends Command {
     public static final String MESSAGE_ARGUMENTS = "Index: %1$s, new tag: %2$s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add tags for a student in the student map.\n"
-        + "Parameters:\n"
-        + "  INDEX (must be a positive integer or use \"all\" to add tags for everyone in the list) \n"
-        + "  [" + PREFIX_TAG + "TAG]...\n"
-        + "Example:\n" + COMMAND_WORD + " 1 "
-        + PREFIX_TAG + "lab "
-        + PREFIX_TAG + "goodProgress"
-        + "\nor\n" + COMMAND_WORD + " all "
-        + PREFIX_TAG + "tutorial "
-        + PREFIX_TAG + "needRemedial";
+            + "Parameters:\n"
+            + "  INDEX (must be a positive integer or use \"all\" to add tags for everyone in the list) \n"
+            + "  [" + PREFIX_TAG + "TAG]...\n"
+            + "Example:\n" + COMMAND_WORD + " 1 "
+            + PREFIX_TAG + "lab "
+            + PREFIX_TAG + "goodProgress"
+            + "\nor\n" + COMMAND_WORD + " all "
+            + PREFIX_TAG + "tutorial "
+            + PREFIX_TAG + "needRemedial";
 
     public static final String MESSAGE_SINGLE_ADD_TAGS_SUCCESS = "Added tags %1$s Student: %2$s";
 
@@ -46,118 +47,17 @@ public class AddTagCommand extends Command {
 
     public static final String MESSAGE_TAGS_NOT_ADDED = "At least one tag must be added";
 
-    public static final String MESSAGE_DUPLICATE_STUDENT = "This student already exists in the student map.";
-
-    /**
-     * Index of the student to add the tags for.
-     * If index is null, the tags will be added for every student in the list.
-     */
-    private Index index;
-
-    /** The tags to be added.*/
-    private Set<Tag> tags;
-
-    private String toBeAddedTagsStr;
-
-    /** The tags to be added.*/
-    private boolean isAddToAll;
-
-    /**
-     * Constructs AddTagCommand that will add specified tag to all students in the
-     * displayed list.
-     *
-     * @param tags of the student to be added
-     */
-    public AddTagCommand(Set<Tag> tags) {
-        requireNonNull(tags);
-
-        this.isAddToAll = true;
-        this.tags = tags;
-        this.toBeAddedTagsStr = tagSetToSting(tags);
-    }
-
-    /**
-     * @param index of the student in the filtered student list to add the tag
-     * @param tags of the student to be added
-     */
-    public AddTagCommand(Index index, Set<Tag> tags) {
-        requireNonNull(tags);
-
-        this.isAddToAll = false;
-        this.index = index;
-        this.tags = tags;
-        this.toBeAddedTagsStr = tagSetToSting(tags);
-    }
-
-    @Override
-    public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-        List<Student> lastShownList = model.getFilteredStudentList();
-        if (this.isAddToAll) {
-            int numOfstudentUpdated = 0;
-            for (int idx = 0; idx < lastShownList.size(); idx++) {
-                Student studentToEdit = lastShownList.get(idx);
-                executeSingle(model, Index.fromZeroBased(idx), studentToEdit);
-                numOfstudentUpdated += 1;
-            }
-            model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-            return new CommandResult(String.format(
-                    MESSAGE_MULTI_ADD_TAGS_SUCCESS,
-                    toBeAddedTagsStr,
-                    numOfstudentUpdated));
-        }
-
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
-        }
-
-        assert !this.isAddToAll && this.index != null
-                : "[AddTagCommand] index should not be null if it is not all";
-        Student studentToEdit = lastShownList.get(index.getZeroBased());
-        CommandResult res = executeSingle(model, this.index, studentToEdit);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-        return res;
-    }
-
-    /**
-     * Adds tags for a single student in the displayed list.
-     * @param model {@code Model} which the command should operate on.
-     * @param index of the student for whom the tags will be added.
-     * @param studentToEdit for whom the tags will be added.
-     * @return feedback message of the operation result for display.
-     * @throws CommandException If an error occurs during command execution.
-     */
-    public CommandResult executeSingle(
-                Model model, Index index, Student studentToEdit) throws CommandException {
-        Set<Tag> existingTags = studentToEdit.getTags();
-        Set<Tag> toBeAddedTags = new HashSet<Tag>();
-        for (Tag tag : existingTags) {
-            if (!this.tags.contains(tag)) {
-                toBeAddedTags.add(tag);
-            }
-        }
-        for (Tag tag : this.tags) {
-            toBeAddedTags.add(tag);
-        }
-        System.out.println(toBeAddedTags);
-        EditCommand.EditStudentDescriptor editStudentDescriptor = new EditCommand.EditStudentDescriptor();
-        editStudentDescriptor.setTags(toBeAddedTags);
-        CommandResult editstudentResult = (new EditCommand(index, editStudentDescriptor)).executeNoRefresh(model);
-        LOGGER.info(editstudentResult.getFeedbackToUser());
-
-        assert index != null : "[AddTagCommand] Index in executeSingle should not be null";
-        return new CommandResult(String.format(
-                MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
-                toBeAddedTagsStr,
-                studentToEdit.getName()));
+    public AddTagCommand(Function<Model, List<Index>> indicesGenerator, AddTagCommandStudentEditor editor) {
+        super(indicesGenerator, editor);
     }
 
     /**
      * Formats the tag set to be more user friendly string.
+     *
      * @param tags set to be formatted.
      * @return the fomatted list of tags/
      */
-    public static String tagSetToSting(Set<Tag> tags) {
+    public static String tagSetToString(Set<Tag> tags) {
         String res = "";
         for (Tag tag : tags) {
             res += tag.toString() + ", ";
@@ -166,20 +66,87 @@ public class AddTagCommand extends Command {
     }
 
     @Override
-    public boolean equals(Object other) {
-        // short circuit if same object
-        if (other == this) {
-            return true;
+    public String getSingleEditSuccessMessage(Student editedStudent) {
+        return String.format(MESSAGE_SINGLE_ADD_TAGS_SUCCESS, tagSetToString(studentEditor.tags),
+                editedStudent.getName());
+    }
+
+    @Override
+    public String getMultiEditSuccessMessage(List<Student> editedStudents) {
+        return String.format(MESSAGE_MULTI_ADD_TAGS_SUCCESS, tagSetToString(studentEditor.tags), editedStudents.size());
+    }
+
+    @Override
+    public String getNoEditMessage() {
+        return MESSAGE_TAGS_NOT_ADDED;
+    }
+
+
+    /**
+     * A static StudentEditor that adds tags to a given Student.
+     */
+    public static class AddTagCommandStudentEditor extends StudentEditor {
+
+        private Set<Tag> tags;
+
+        /**
+         * Parameterless constructor.
+         */
+        public AddTagCommandStudentEditor() {
         }
 
-        // instanceof handles nulls
-        if (!(other instanceof AddTagCommand)) {
-            return false;
+        /**
+         * Constructor with tags.
+         *
+         * @param tags Tags that this editor will add to a given Student.
+         */
+        public AddTagCommandStudentEditor(Set<Tag> tags) {
+            requireNonNull(tags);
+            setTags(tags);
         }
 
-        // state check
-        AddTagCommand e = (AddTagCommand) other;
-        return index.equals(e.index)
-                && this.tags.equals(e.tags);
+        public Optional<Set<Tag>> getTags() {
+            return Optional.ofNullable(tags);
+        }
+
+        public void setTags(Set<Tag> tags) {
+            requireNonNull(tags);
+            this.tags = new HashSet<>(tags);
+        }
+
+        @Override
+        public Student editStudent(Student studentToEdit) {
+            assert studentToEdit != null;
+
+            StudentData studentData = studentToEdit.getStudentData();
+            Set<Tag> newTags = studentData.getTags();
+            newTags.addAll(tags);
+            studentData.setTags(newTags);
+
+            return new Student(studentData);
+        }
+
+        @Override
+        public boolean hasEdits() {
+            return tags != null && tags.size() > 0;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditCommand.EditCommandStudentEditor)) {
+                return false;
+            }
+
+            // state check
+            EditCommand.EditCommandStudentEditor e = (EditCommand.EditCommandStudentEditor) other;
+
+            return getTags().equals(e.getTags());
+        }
     }
 }

--- a/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
@@ -83,7 +83,7 @@ public class AddTagCommand extends EditStudentCommand<AddTagCommand.AddTagComman
     /**
      * A static StudentEditor that adds tags to a given Student.
      */
-    public static class AddTagCommandStudentEditor extends StudentEditor {
+    public static class AddTagCommandStudentEditor implements StudentEditor {
 
         private Set<Tag> tags;
 

--- a/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
@@ -7,14 +7,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.logging.Logger;
 
 import seedu.studmap.MainApp;
 import seedu.studmap.commons.core.LogsCenter;
-import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.logic.commands.commons.StudentEditor;
-import seedu.studmap.model.Model;
 import seedu.studmap.model.student.Student;
 import seedu.studmap.model.student.StudentData;
 import seedu.studmap.model.tag.Tag;
@@ -47,12 +45,12 @@ public class AddTagCommand extends EditStudentCommand<AddTagCommand.AddTagComman
 
     public static final String MESSAGE_TAGS_NOT_ADDED = "At least one tag must be added";
 
-    public AddTagCommand(Function<Model, List<Index>> indicesGenerator, AddTagCommandStudentEditor editor) {
-        super(indicesGenerator, editor);
+    public AddTagCommand(IndexListGenerator indexListGenerator, AddTagCommandStudentEditor editor) {
+        super(indexListGenerator, editor);
     }
 
     /**
-     * Formats the tag set to be more user friendly string.
+     * Formats the tag set to be more user-friendly string.
      *
      * @param tags set to be formatted.
      * @return the fomatted list of tags/

--- a/src/main/java/seedu/studmap/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditCommand.java
@@ -68,23 +68,9 @@ public class EditCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-        List<Student> lastShownList = model.getFilteredStudentList();
-
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
-        }
-
-        Student studentToEdit = lastShownList.get(index.getZeroBased());
-        Student editedStudent = createEditedStudent(studentToEdit, editStudentDescriptor);
-
-        if (!studentToEdit.isSameStudent(editedStudent) && model.hasStudent(editedStudent)) {
-            throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
-        }
-
-        model.setStudent(studentToEdit, editedStudent);
+        CommandResult c = executeNoRefresh(model);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-        return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent));
+        return c;
     }
 
     /**

--- a/src/main/java/seedu/studmap/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditCommand.java
@@ -98,7 +98,7 @@ public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStude
      * Stores the details to edit the student with. Each non-empty field value will replace the
      * corresponding field value of the student.
      */
-    public static class EditCommandStudentEditor extends StudentEditor {
+    public static class EditCommandStudentEditor implements StudentEditor {
         private Name name;
         private Phone phone;
         private Email email;

--- a/src/main/java/seedu/studmap/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditCommand.java
@@ -12,9 +12,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
-import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.commons.util.CollectionUtil;
 import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.logic.commands.exceptions.CommandException;
@@ -51,8 +50,8 @@ public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStude
     public static final String MESSAGE_EDIT_MULTIPLE_STUDENTS_SUCCESS = "Edited %1$d students.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
-    public EditCommand(Function<Model, List<Index>> indicesGenerator, EditCommandStudentEditor studentEditor) {
-        super(indicesGenerator, studentEditor);
+    public EditCommand(IndexListGenerator indexListGenerator, EditCommandStudentEditor studentEditor) {
+        super(indexListGenerator, studentEditor);
     }
 
     @Override

--- a/src/main/java/seedu/studmap/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditCommand.java
@@ -1,6 +1,5 @@
 package seedu.studmap.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_NAME;
@@ -13,10 +12,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
-import seedu.studmap.commons.core.Messages;
 import seedu.studmap.commons.core.index.Index;
 import seedu.studmap.commons.util.CollectionUtil;
+import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.logic.commands.exceptions.CommandException;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.student.Address;
@@ -30,7 +30,7 @@ import seedu.studmap.model.tag.Tag;
 /**
  * Edits the details of an existing student in the student map.
  */
-public class EditCommand extends Command {
+public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStudentEditor> {
 
     public static final String COMMAND_WORD = "edit";
 
@@ -48,22 +48,26 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited Student: %1$s";
+    public static final String MESSAGE_EDIT_MULTIPLE_STUDENTS_SUCCESS = "Edited %1$d students.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_STUDENT = "This student already exists in the student map.";
 
-    private final Index index;
-    private final EditStudentDescriptor editStudentDescriptor;
+    public EditCommand(Function<Model, List<Index>> indicesGenerator, EditCommandStudentEditor studentEditor) {
+        super(indicesGenerator, studentEditor);
+    }
 
-    /**
-     * @param index of the student in the filtered student list to edit
-     * @param editStudentDescriptor details to edit the student with
-     */
-    public EditCommand(Index index, EditStudentDescriptor editStudentDescriptor) {
-        requireNonNull(index);
-        requireNonNull(editStudentDescriptor);
+    @Override
+    public String getSingleEditSuccessMessage(Student editedStudent) {
+        return String.format(MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);
+    }
 
-        this.index = index;
-        this.editStudentDescriptor = new EditStudentDescriptor(editStudentDescriptor);
+    @Override
+    public String getMultiEditSuccessMessage(List<Student> editedStudents) {
+        return String.format(MESSAGE_EDIT_MULTIPLE_STUDENTS_SUCCESS, editedStudents.size());
+    }
+
+    @Override
+    public String getNoEditMessage() {
+        return MESSAGE_NOT_EDITED;
     }
 
     @Override
@@ -71,49 +75,6 @@ public class EditCommand extends Command {
         CommandResult c = executeNoRefresh(model);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return c;
-    }
-
-    /**
-     * Edits the student without returning to the full students list.
-     * @param model {@code Model} which the command should operate on.
-     * @return feedback message of the operation result for display.
-     * @throws CommandException If an error occurs during command execution.
-     */
-    public CommandResult executeNoRefresh(Model model) throws CommandException {
-        requireNonNull(model);
-        List<Student> lastShownList = model.getFilteredStudentList();
-
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
-        }
-
-        Student studentToEdit = lastShownList.get(index.getZeroBased());
-        Student editedStudent = createEditedStudent(studentToEdit, editStudentDescriptor);
-
-        if (!studentToEdit.isSameStudent(editedStudent) && model.hasStudent(editedStudent)) {
-            throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
-        }
-
-        model.setStudent(studentToEdit, editedStudent);
-        return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent));
-    }
-
-    /**
-     * Creates and returns a {@code Student} with the details of {@code studentToEdit}
-     * edited with {@code editStudentDescriptor}.
-     */
-    private static Student createEditedStudent(Student studentToEdit, EditStudentDescriptor editStudentDescriptor) {
-        assert studentToEdit != null;
-
-        StudentData studentData = new StudentData();
-        studentData.setName(editStudentDescriptor.getName().orElse(studentToEdit.getName()));
-        studentData.setPhone(editStudentDescriptor.getPhone().orElse(studentToEdit.getPhone()));
-        studentData.setEmail(editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail()));
-        studentData.setAddress(editStudentDescriptor.getAddress().orElse(studentToEdit.getAddress()));
-        studentData.setTags(editStudentDescriptor.getTags().orElse(studentToEdit.getTags()));
-        studentData.setAttendances(studentToEdit.getAttendances());
-
-        return new Student(studentData);
     }
 
     @Override
@@ -130,28 +91,29 @@ public class EditCommand extends Command {
 
         // state check
         EditCommand e = (EditCommand) other;
-        return index.equals(e.index)
-                && editStudentDescriptor.equals(e.editStudentDescriptor);
+        return indicesToEdit.equals(e.indicesToEdit)
+                && studentEditor.equals(e.studentEditor);
     }
 
     /**
      * Stores the details to edit the student with. Each non-empty field value will replace the
      * corresponding field value of the student.
      */
-    public static class EditStudentDescriptor {
+    public static class EditCommandStudentEditor extends StudentEditor {
         private Name name;
         private Phone phone;
         private Email email;
         private Address address;
         private Set<Tag> tags;
 
-        public EditStudentDescriptor() {}
+        public EditCommandStudentEditor() {
+        }
 
         /**
          * Copy constructor.
          * A defensive copy of {@code tags} is used internally.
          */
-        public EditStudentDescriptor(EditStudentDescriptor toCopy) {
+        public EditCommandStudentEditor(EditCommandStudentEditor toCopy) {
             setName(toCopy.name);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
@@ -166,44 +128,36 @@ public class EditCommand extends Command {
             return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
         }
 
-        public void setName(Name name) {
-            this.name = name;
-        }
-
         public Optional<Name> getName() {
             return Optional.ofNullable(name);
         }
 
-        public void setPhone(Phone phone) {
-            this.phone = phone;
+        public void setName(Name name) {
+            this.name = name;
         }
 
         public Optional<Phone> getPhone() {
             return Optional.ofNullable(phone);
         }
 
-        public void setEmail(Email email) {
-            this.email = email;
+        public void setPhone(Phone phone) {
+            this.phone = phone;
         }
 
         public Optional<Email> getEmail() {
             return Optional.ofNullable(email);
         }
 
-        public void setAddress(Address address) {
-            this.address = address;
+        public void setEmail(Email email) {
+            this.email = email;
         }
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
         }
 
-        /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public void setTags(Set<Tag> tags) {
-            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        public void setAddress(Address address) {
+            this.address = address;
         }
 
         /**
@@ -215,6 +169,14 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
         @Override
         public boolean equals(Object other) {
             // short circuit if same object
@@ -223,18 +185,37 @@ public class EditCommand extends Command {
             }
 
             // instanceof handles nulls
-            if (!(other instanceof EditStudentDescriptor)) {
+            if (!(other instanceof EditCommandStudentEditor)) {
                 return false;
             }
 
             // state check
-            EditStudentDescriptor e = (EditStudentDescriptor) other;
+            EditCommandStudentEditor e = (EditCommandStudentEditor) other;
 
             return getName().equals(e.getName())
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getTags().equals(e.getTags());
+        }
+
+        @Override
+        public Student editStudent(Student studentToEdit) {
+            assert studentToEdit != null;
+
+            StudentData studentData = studentToEdit.getStudentData();
+            studentData.setName(getName().orElse(studentToEdit.getName()));
+            studentData.setPhone(getPhone().orElse(studentToEdit.getPhone()));
+            studentData.setEmail(getEmail().orElse(studentToEdit.getEmail()));
+            studentData.setAddress(getAddress().orElse(studentToEdit.getAddress()));
+            studentData.setTags(getTags().orElse(studentToEdit.getTags()));
+
+            return new Student(studentData);
+        }
+
+        @Override
+        public boolean hasEdits() {
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
         }
     }
 }

--- a/src/main/java/seedu/studmap/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditStudentCommand.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 import seedu.studmap.commons.core.Messages;
 import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.logic.commands.exceptions.CommandException;
 import seedu.studmap.model.Model;
@@ -27,12 +28,12 @@ public abstract class EditStudentCommand<T extends StudentEditor> extends Comman
     protected Function<Model, List<Index>> indicesToEdit;
 
     /**
-     * @param indicesGenerator Function that produces list of indices of students
+     * @param indexListGenerator Function that produces list of indices of students
      *                         in the filtered student list to edit
      * @param studentEditor    details to edit the student(s) with
      */
-    protected EditStudentCommand(Function<Model, List<Index>> indicesGenerator, T studentEditor) {
-        this.indicesToEdit = indicesGenerator;
+    protected EditStudentCommand(IndexListGenerator indexListGenerator, T studentEditor) {
+        this.indicesToEdit = indexListGenerator;
         this.studentEditor = studentEditor;
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditStudentCommand.java
@@ -1,0 +1,118 @@
+package seedu.studmap.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.studmap.commons.core.Messages.MESSAGE_DUPLICATE_STUDENT;
+import static seedu.studmap.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import seedu.studmap.commons.core.Messages;
+import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.logic.commands.commons.StudentEditor;
+import seedu.studmap.logic.commands.exceptions.CommandException;
+import seedu.studmap.model.Model;
+import seedu.studmap.model.student.Student;
+
+/**
+ * Abstract class for any command that wants to edit student fields. Provides some basic abstractions to reduce
+ * duplicated code, such as the main execution of the command (retrieval of StudentData etc.)
+ *
+ * @param <T> StudentEditor that this command uses to edit each specified Student.
+ */
+public abstract class EditStudentCommand<T extends StudentEditor> extends Command {
+
+    protected T studentEditor;
+    protected Function<Model, List<Index>> indicesToEdit;
+
+    /**
+     * @param indicesGenerator Function that produces list of indices of students
+     *                         in the filtered student list to edit
+     * @param studentEditor    details to edit the student(s) with
+     */
+    protected EditStudentCommand(Function<Model, List<Index>> indicesGenerator, T studentEditor) {
+        this.indicesToEdit = indicesGenerator;
+        this.studentEditor = studentEditor;
+    }
+
+    public abstract String getSingleEditSuccessMessage(Student editedStudent);
+
+    public abstract String getMultiEditSuccessMessage(List<Student> editedStudents);
+
+    public abstract String getNoEditMessage();
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        CommandResult c = executeNoRefresh(model);
+        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
+        return c;
+    }
+
+    /**
+     * Edits the student without returning to the full students list.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display.
+     * @throws CommandException If an error occurs during command execution.
+     */
+    public CommandResult executeNoRefresh(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Student> lastShownList = model.getFilteredStudentList();
+
+        ArrayList<Student> editedStudents = new ArrayList<>();
+
+        for (Index index : indicesToEdit.apply(model)) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+            }
+
+            Student studentToEdit = lastShownList.get(index.getZeroBased());
+            Student editedStudent = studentEditor.editStudent(studentToEdit);
+
+            if (!studentToEdit.isSameStudent(editedStudent) && model.hasStudent(editedStudent)) {
+                throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
+            }
+
+            if (studentEditor.hasEdits()) {
+                editedStudents.add(editedStudent);
+            }
+
+            model.setStudent(studentToEdit, editedStudent);
+        }
+
+        if (editedStudents.size() == 0) {
+            return new CommandResult(getNoEditMessage());
+        } else if (editedStudents.size() == 1) {
+            return new CommandResult(getSingleEditSuccessMessage(editedStudents.get(0)));
+        } else {
+            return new CommandResult(getMultiEditSuccessMessage(editedStudents));
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditStudentCommand)) {
+            return false;
+        }
+
+        // state check
+        EditStudentCommand e = (EditStudentCommand) other;
+
+        return indicesToEdit.equals(e.indicesToEdit) && studentEditor.equals(e.studentEditor);
+    }
+
+    /**
+     * Returns true if this command will make edits when executed.
+     */
+    public boolean hasEdits() {
+        return studentEditor.hasEdits();
+    }
+
+}

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -1,17 +1,13 @@
 package seedu.studmap.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
-import static seedu.studmap.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import seedu.studmap.commons.core.Messages;
-import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.logic.commands.exceptions.CommandException;
-import seedu.studmap.model.Model;
+import seedu.studmap.commons.core.index.IndexListGenerator;
+import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Student;
 import seedu.studmap.model.student.StudentData;
@@ -19,7 +15,7 @@ import seedu.studmap.model.student.StudentData;
 /**
  * Marks a student identified using its displayed index from the student map as having attended a class or tutorial.
  */
-public class MarkCommand extends Command {
+public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStudentEditor> {
 
     public static final String COMMAND_WORD = "mark";
 
@@ -30,60 +26,83 @@ public class MarkCommand extends Command {
             + PREFIX_CLASS + " [CLASS]\n"
             + "Example: " + COMMAND_WORD + " 1 present " + PREFIX_CLASS + " T01";
 
-    public static final String MESSAGE_MARK_SUCCESS = "Marked Student as %1$s: %2$s";
+    public static final String MESSAGE_MARK_SINGLE_SUCCESS = "Marked Student as %1$s: %2$s";
+    public static final String MESSAGE_MARK_MULTI_SUCCESS = "Marked %1$s students as %2$s";
 
-    private final Index index;
-    private final Attendance attendance;
+    public static final String MESSAGE_NO_EDIT = "Attendance must be provided.";
+
+    public MarkCommand(IndexListGenerator indexListGenerator, MarkCommandStudentEditor studentEditor) {
+        super(indexListGenerator, studentEditor);
+    }
+
+    @Override
+    public String getSingleEditSuccessMessage(Student editedStudent) {
+        return String.format(MESSAGE_MARK_SINGLE_SUCCESS, studentEditor.getAttendance().getAttendanceString(),
+                editedStudent);
+    }
+
+    @Override
+    public String getMultiEditSuccessMessage(List<Student> editedStudents) {
+        return String.format(MESSAGE_MARK_MULTI_SUCCESS, editedStudents.size(), studentEditor.getAttendance());
+    }
+
+    @Override
+    public String getNoEditMessage() {
+        return MESSAGE_NO_EDIT;
+    }
 
     /**
-     * @param index Index of the student in the filtered student list to edit the attendance
-     * @param attendance Attendance of the student to be added
+     * A static StudentEditor that adjusts Attendance for a given Student.
      */
-    public MarkCommand(Index index, Attendance attendance) {
-        this.index = index;
-        this.attendance = attendance;
-    }
+    public static class MarkCommandStudentEditor extends StudentEditor {
 
-    @Override
-    public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
+        private final Attendance attendance;
 
-        List<Student> lastShownList = model.getFilteredStudentList();
-
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        /**
+         * Constructor using Attendance.
+         *
+         * @param attendance Attendance to edit the student with.
+         */
+        public MarkCommandStudentEditor(Attendance attendance) {
+            this.attendance = attendance;
         }
 
-        Student studentToEdit = lastShownList.get(index.getZeroBased());
-        StudentData studentData = studentToEdit.getStudentData();
-
-        Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
-        newAttendance.add(attendance);
-        studentData.setAttendances(newAttendance);
-        Student editedStudent = new Student(studentData);
-
-        model.setStudent(studentToEdit, editedStudent);
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-
-        return new CommandResult(
-                String.format(MESSAGE_MARK_SUCCESS, attendance.getAttendance(), editedStudent));
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        // short circuit if same object
-        if (other == this) {
-            return true;
+        public Attendance getAttendance() {
+            return attendance;
         }
 
-        // instanceof handles nulls
-        if (!(other instanceof MarkCommand)) {
-            return false;
+        @Override
+        public Student editStudent(Student studentToEdit) {
+            StudentData studentData = studentToEdit.getStudentData();
+
+            Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
+            newAttendance.add(attendance);
+            studentData.setAttendances(newAttendance);
+            return new Student(studentData);
         }
 
-        // state check
-        MarkCommand e = (MarkCommand) other;
-        return index.equals(e.index)
-                && attendance.equals(e.attendance);
+        @Override
+        public boolean hasEdits() {
+            return attendance != null;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof MarkCommand.MarkCommandStudentEditor)) {
+                return false;
+            }
+
+            // state check
+            MarkCommand.MarkCommandStudentEditor e = (MarkCommand.MarkCommandStudentEditor) other;
+
+            return getAttendance().equals(e.getAttendance());
+        }
     }
 }

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -22,9 +22,11 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the attendance for student identified by the index number used in the displayed"
             + " student list.\n Marks attendance for the class or tutorial specified in the parameter.\n"
-            + "Parameters: INDEX (must be positive integer) OPTION (must be absent/present) "
+            + "Parameters: INDEX (must be positive integer or use \"all\" to mark everyone currently displayed)"
+            + " OPTION (must be absent/present) "
             + PREFIX_CLASS + " [CLASS]\n"
-            + "Example: " + COMMAND_WORD + " 1 present " + PREFIX_CLASS + " T01";
+            + "Example: " + COMMAND_WORD + " 1 present " + PREFIX_CLASS + "T01\n"
+            + "Example: " + COMMAND_WORD + " all present " + PREFIX_CLASS + "T07";
 
     public static final String MESSAGE_MARK_SINGLE_SUCCESS = "Marked Student as %1$s: %2$s";
     public static final String MESSAGE_MARK_MULTI_SUCCESS = "Marked %1$s students as %2$s";
@@ -54,7 +56,7 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     /**
      * A static StudentEditor that adjusts Attendance for a given Student.
      */
-    public static class MarkCommandStudentEditor extends StudentEditor {
+    public static class MarkCommandStudentEditor implements StudentEditor {
 
         private final Attendance attendance;
 

--- a/src/main/java/seedu/studmap/logic/commands/commons/StudentEditor.java
+++ b/src/main/java/seedu/studmap/logic/commands/commons/StudentEditor.java
@@ -5,18 +5,19 @@ import seedu.studmap.model.student.Student;
 /**
  * An abstract class that encapsulates the manner in which a student may be edited.
  */
-public abstract class StudentEditor {
+public interface StudentEditor {
 
     /**
      * Creates a new student by editing a given student.
      * Editing behaviour is to be defined in the inherited class.
+     *
      * @param studentToEdit Student to be edited
      * @return New edited student
      */
-    public abstract Student editStudent(Student studentToEdit);
+    Student editStudent(Student studentToEdit);
 
     /**
      * Returns true if this editor will make edits when used.
      */
-    public abstract boolean hasEdits();
+    boolean hasEdits();
 }

--- a/src/main/java/seedu/studmap/logic/commands/commons/StudentEditor.java
+++ b/src/main/java/seedu/studmap/logic/commands/commons/StudentEditor.java
@@ -1,0 +1,22 @@
+package seedu.studmap.logic.commands.commons;
+
+import seedu.studmap.model.student.Student;
+
+/**
+ * An abstract class that encapsulates the manner in which a student may be edited.
+ */
+public abstract class StudentEditor {
+
+    /**
+     * Creates a new student by editing a given student.
+     * Editing behaviour is to be defined in the inherited class.
+     * @param studentToEdit Student to be edited
+     * @return New edited student
+     */
+    public abstract Student editStudent(Student studentToEdit);
+
+    /**
+     * Returns true if this editor will make edits when used.
+     */
+    public abstract boolean hasEdits();
+}

--- a/src/main/java/seedu/studmap/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/AddTagCommandParser.java
@@ -40,8 +40,8 @@ public class AddTagCommandParser extends EditStudentCommandParser<AddTagCommand.
     }
 
     @Override
-    public EditStudentCommand<AddTagCommand.AddTagCommandStudentEditor>
-            getIndexCommand(ArgumentMultimap argMultimap, IndexListGenerator indexListGenerator)
+    public EditStudentCommand<AddTagCommand.AddTagCommandStudentEditor> getIndexCommand(
+            ArgumentMultimap argMultimap, IndexListGenerator indexListGenerator)
             throws ParseException {
 
         Set<Tag> tags;

--- a/src/main/java/seedu/studmap/logic/parser/AddTagCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/AddTagCommandParser.java
@@ -1,51 +1,21 @@
 package seedu.studmap.logic.parser;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
-import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.commons.exceptions.IllegalValueException;
+import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.logic.commands.AddTagCommand;
+import seedu.studmap.logic.commands.EditStudentCommand;
 import seedu.studmap.logic.parser.exceptions.ParseException;
 import seedu.studmap.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddTagCommand object
  */
-public class AddTagCommandParser implements Parser<AddTagCommand> {
-
-    /**
-     * Parses the given {@code String} of arguments in the context of the AddTagCommand
-     * and returns an AddTagCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
-     */
-    public AddTagCommand parse(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
-
-        Index index;
-        Set<Tag> tags;
-        try {
-            tags = parseTagsSet(argMultimap.getAllValues(PREFIX_TAG));
-            if (tags.size() == 0) {
-                throw new ParseException(AddTagCommand.MESSAGE_TAGS_NOT_ADDED);
-            }
-            if (argMultimap.getPreamble().equalsIgnoreCase("all")) {
-                return new AddTagCommand(tags);
-            }
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddTagCommand.MESSAGE_USAGE), ive);
-        }
-
-        return new AddTagCommand(index, tags);
-    }
+public class AddTagCommandParser extends EditStudentCommandParser<AddTagCommand.AddTagCommandStudentEditor> {
 
     /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
@@ -57,5 +27,30 @@ public class AddTagCommandParser implements Parser<AddTagCommand> {
 
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return ParserUtil.parseTags(tagSet);
+    }
+
+    @Override
+    public Prefix[] getPrefixes() {
+        return new Prefix[]{PREFIX_TAG};
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return AddTagCommand.MESSAGE_USAGE;
+    }
+
+    @Override
+    public EditStudentCommand<AddTagCommand.AddTagCommandStudentEditor>
+            getIndexCommand(ArgumentMultimap argMultimap, IndexListGenerator indexListGenerator)
+            throws ParseException {
+
+        Set<Tag> tags;
+        tags = parseTagsSet(argMultimap.getAllValues(PREFIX_TAG));
+
+        AddTagCommand.AddTagCommandStudentEditor editor = new AddTagCommand.AddTagCommandStudentEditor();
+        editor.setTags(tags);
+
+        return new AddTagCommand(indexListGenerator, editor);
+
     }
 }

--- a/src/main/java/seedu/studmap/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/EditCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.studmap.logic.parser;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_NAME;
@@ -13,55 +11,49 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.logic.commands.EditCommand;
-import seedu.studmap.logic.commands.EditCommand.EditStudentDescriptor;
+import seedu.studmap.logic.commands.EditCommand.EditCommandStudentEditor;
+import seedu.studmap.logic.commands.EditStudentCommand;
 import seedu.studmap.logic.parser.exceptions.ParseException;
 import seedu.studmap.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new EditCommand object
  */
-public class EditCommandParser implements Parser<EditCommand> {
+public class EditCommandParser extends EditStudentCommandParser<EditCommandStudentEditor> {
 
-    /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
-     */
-    public EditCommand parse(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+    @Override
+    public Prefix[] getPrefixes() {
+        return new Prefix[]{PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG};
+    }
 
-        Index index;
+    @Override
+    public String getUsageMessage() {
+        return EditCommand.MESSAGE_USAGE;
+    }
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
-        }
+    @Override
+    public EditStudentCommand<EditCommandStudentEditor> getIndexCommand(
+            ArgumentMultimap argMultimap, IndexListGenerator indexListGenerator) throws ParseException {
 
-        EditCommand.EditStudentDescriptor editStudentDescriptor = new EditStudentDescriptor();
+        EditCommand.EditCommandStudentEditor editor = new EditCommand.EditCommandStudentEditor();
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editStudentDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            editor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editStudentDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+            editor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editStudentDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            editor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editStudentDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            editor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editStudentDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editor::setTags);
 
-        if (!editStudentDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
-        }
-
-        return new EditCommand(index, editStudentDescriptor);
+        return new EditCommand(indexListGenerator, editor);
     }
 
     /**

--- a/src/main/java/seedu/studmap/logic/parser/EditStudentCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/EditStudentCommandParser.java
@@ -1,0 +1,23 @@
+package seedu.studmap.logic.parser;
+
+import seedu.studmap.logic.commands.EditStudentCommand;
+import seedu.studmap.logic.commands.commons.StudentEditor;
+import seedu.studmap.logic.parser.exceptions.ParseException;
+
+/**
+ * An in-between abstract class to flatten the class declaration.
+ *
+ * @param <S> StudentEditor that is used by the EditStudentCommand which this parser produces.
+ */
+public abstract class EditStudentCommandParser<S extends StudentEditor>
+        implements IndexCommandParser<EditStudentCommand<S>> {
+
+    @Override
+    public EditStudentCommand<S> parse(String args) throws ParseException {
+        EditStudentCommand<S> command = IndexCommandParser.super.parse(args);
+        if (!command.hasEdits()) {
+            throw new ParseException(command.getNoEditMessage());
+        }
+        return command;
+    }
+}

--- a/src/main/java/seedu/studmap/logic/parser/EditStudentCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/EditStudentCommandParser.java
@@ -1,5 +1,8 @@
 package seedu.studmap.logic.parser;
 
+import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.studmap.logic.parser.ParserUtil.separatePreamble;
+
 import seedu.studmap.logic.commands.EditStudentCommand;
 import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.logic.parser.exceptions.ParseException;
@@ -19,5 +22,12 @@ public abstract class EditStudentCommandParser<S extends StudentEditor>
             throw new ParseException(command.getNoEditMessage());
         }
         return command;
+    }
+
+    @Override
+    public void validatePreamble(String preamble) throws ParseException {
+        if (separatePreamble(preamble).length != 1) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+        }
     }
 }

--- a/src/main/java/seedu/studmap/logic/parser/IndexCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/IndexCommandParser.java
@@ -3,6 +3,7 @@ package seedu.studmap.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.studmap.logic.parser.ParserUtil.separatePreamble;
 
 import java.util.List;
 
@@ -53,10 +54,17 @@ public interface IndexCommandParser<T extends Command> extends Parser<T> {
 
         Index index;
         try {
-            if (argMultimap.getPreamble().equalsIgnoreCase(ALL_INDEX)) {
+            String preamble = argMultimap.getPreamble();
+            String[] preambleArgs = separatePreamble(preamble);
+
+            validatePreamble(preamble);
+
+            if (preambleArgs[0].equalsIgnoreCase(ALL_INDEX)) {
                 return getIndexCommand(argMultimap, new AllIndexGenerator());
             }
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+            index = ParserUtil.parseIndex(preambleArgs[0]);
+
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageMessage()), pe);
         }
@@ -74,5 +82,12 @@ public interface IndexCommandParser<T extends Command> extends Parser<T> {
      */
     T getIndexCommand(ArgumentMultimap argMultimap,
                       IndexListGenerator indexListGenerator) throws ParseException;
+
+    /**
+     * Validates a given preamble.
+     *
+     * @throws ParseException if preamble is invalid.
+     */
+    void validatePreamble(String preamble) throws ParseException;
 
 }

--- a/src/main/java/seedu/studmap/logic/parser/IndexCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/IndexCommandParser.java
@@ -1,0 +1,78 @@
+package seedu.studmap.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+
+import seedu.studmap.commons.core.index.AllIndexGenerator;
+import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.IndexListGenerator;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
+import seedu.studmap.logic.commands.Command;
+import seedu.studmap.logic.parser.exceptions.ParseException;
+
+/**
+ * An interface that provides a framework for a parser for commands that will need to manipulate
+ * a number of students based on their indices.
+ *
+ * @param <T> Command type that this parser will parse.
+ */
+public interface IndexCommandParser<T extends Command> extends Parser<T> {
+
+    String ALL_INDEX = "all";
+
+    /**
+     * Returns an array of prefixes that will tokenize the arguments string.
+     */
+    Prefix[] getPrefixes();
+
+    /**
+     * Returns the usage message for the command to be produced.
+     */
+    String getUsageMessage();
+
+    /**
+     * Parses given arguments and returns a command.
+     * The default implementation will look for an index (and in the case of the keyword 'all',
+     * it returns a function that produces all the available indices.
+     *
+     * @param args Command arguments
+     * @return Command for execution
+     * @throws ParseException if any errors arise when parsing this command
+     */
+    default T parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        Prefix[] prefixes = getPrefixes();
+        requireNonNull(prefixes);
+        requireAllNonNull(List.of(prefixes));
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, prefixes);
+
+        Index index;
+        try {
+            if (argMultimap.getPreamble().equalsIgnoreCase(ALL_INDEX)) {
+                return getIndexCommand(argMultimap, new AllIndexGenerator());
+            }
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageMessage()), pe);
+        }
+
+        return getIndexCommand(argMultimap, new SingleIndexGenerator(index));
+    }
+
+    /**
+     * Produces a command promised by this interface. This is called in the `parse` method to generate the command
+     * after automatic tokenization.
+     *
+     * @param argMultimap        Argument multimap to process
+     * @param indexListGenerator students affected by this command, wrapped in a function to be used later.
+     * @throws ParseException if any errors arise when parsing this command.
+     */
+    T getIndexCommand(ArgumentMultimap argMultimap,
+                      IndexListGenerator indexListGenerator) throws ParseException;
+
+}

--- a/src/main/java/seedu/studmap/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/MarkCommandParser.java
@@ -1,11 +1,11 @@
 package seedu.studmap.logic.parser;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
+import static seedu.studmap.logic.parser.ParserUtil.separatePreamble;
 
-import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.commons.exceptions.IllegalValueException;
+import seedu.studmap.commons.core.index.IndexListGenerator;
+import seedu.studmap.logic.commands.EditStudentCommand;
 import seedu.studmap.logic.commands.MarkCommand;
 import seedu.studmap.logic.parser.exceptions.ParseException;
 import seedu.studmap.model.student.Attendance;
@@ -13,40 +13,43 @@ import seedu.studmap.model.student.Attendance;
 /**
  * Parses input arguments and creates a new MarkCommand object
  */
-public class MarkCommandParser implements Parser<MarkCommand> {
+public class MarkCommandParser extends EditStudentCommandParser<MarkCommand.MarkCommandStudentEditor> {
 
     public static final String MESSAGE_INVALID_OPTION = "Option must either be 'present' or 'absent'!";
+
+    @Override
+    public Prefix[] getPrefixes() {
+        return new Prefix[]{PREFIX_CLASS};
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return MarkCommand.MESSAGE_USAGE;
+    }
 
     /**
      * Parses the given {@code String} of arguments in the context of the MarkCommand
      * and returns a MarkCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
-    public MarkCommand parse(String args) throws ParseException {
+    @Override
+    public EditStudentCommand<MarkCommand.MarkCommandStudentEditor> getIndexCommand(
+            ArgumentMultimap argMultimap, IndexListGenerator indexListGenerator) throws ParseException {
 
-        ParseException parseException = new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                MarkCommand.MESSAGE_USAGE));
-        requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_CLASS);
-
-        Index index;
         String[] preamble = argMultimap.getPreamble().split("\\s+");
         if (preamble.length != 2) {
-            throw parseException;
-        }
-
-        try {
-            index = ParserUtil.parseIndex(preamble[0]);
-        } catch (IllegalValueException ive) {
-            throw parseException;
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
         }
 
         boolean attended = parseOption(preamble[1]);
         String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).orElse(""));
         Attendance attendance = new Attendance(className, attended);
 
-        return new MarkCommand(index, attendance);
+        MarkCommand.MarkCommandStudentEditor editor = new MarkCommand.MarkCommandStudentEditor(attendance);
+
+        return new MarkCommand(indexListGenerator, editor);
+
     }
 
     private boolean parseOption(String option) throws ParseException {
@@ -56,6 +59,13 @@ public class MarkCommandParser implements Parser<MarkCommand> {
             return false;
         } else {
             throw new ParseException(MESSAGE_INVALID_OPTION);
+        }
+    }
+
+    @Override
+    public void validatePreamble(String preamble) throws ParseException {
+        if (separatePreamble(preamble).length != 2) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
         }
     }
 }

--- a/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
@@ -38,6 +38,13 @@ public class ParserUtil {
     }
 
     /**
+     * Separates {@code preamble} into an array of strings for processing.
+     */
+    public static String[] separatePreamble(String preamble) {
+        return preamble.split("\\s+");
+    }
+
+    /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/studmap/model/Model.java
+++ b/src/main/java/seedu/studmap/model/Model.java
@@ -1,10 +1,12 @@
 package seedu.studmap.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.studmap.commons.core.GuiSettings;
+import seedu.studmap.commons.core.index.Index;
 import seedu.studmap.model.attribute.Attribute;
 import seedu.studmap.model.order.Order;
 import seedu.studmap.model.student.Student;
@@ -87,6 +89,11 @@ public interface Model {
      * Returns an unmodifiable view of the filtered student list
      */
     ObservableList<Student> getFilteredStudentList();
+
+    /**
+     * Returns a list of indices of the filtered student list
+     */
+    List<Index> getFilteredStudentIndices();
 
     /**
      * Updates the filter of the filtered student list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/studmap/model/ModelManager.java
+++ b/src/main/java/seedu/studmap/model/ModelManager.java
@@ -4,13 +4,17 @@ import static java.util.Objects.requireNonNull;
 import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.studmap.commons.core.GuiSettings;
 import seedu.studmap.commons.core.LogsCenter;
+import seedu.studmap.commons.core.index.Index;
 import seedu.studmap.model.attribute.Attribute;
 import seedu.studmap.model.order.Order;
 import seedu.studmap.model.student.Student;
@@ -122,6 +126,11 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Student> getFilteredStudentList() {
         return filteredStudents;
+    }
+
+    @Override
+    public List<Index> getFilteredStudentIndices() {
+        return IntStream.range(0, filteredStudents.size()).mapToObj(Index::fromZeroBased).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/seedu/studmap/model/student/Attendance.java
+++ b/src/main/java/seedu/studmap/model/student/Attendance.java
@@ -39,10 +39,10 @@ public class Attendance {
     }
 
     public String getString() {
-        return className + ':' + getAttendance();
+        return className + ':' + getAttendanceString();
     }
 
-    public String getAttendance() {
+    public String getAttendanceString() {
         return (hasAttended ? ATTENDANCE_TRUE : ATTENDANCE_FALSE);
     }
 

--- a/src/main/java/seedu/studmap/model/student/Student.java
+++ b/src/main/java/seedu/studmap/model/student/Student.java
@@ -93,13 +93,17 @@ public class Student {
     }
 
     public StudentData getStudentData() {
+
         StudentData studentData = new StudentData();
+
         studentData.setName(this.getName());
         studentData.setPhone(this.getPhone());
         studentData.setEmail(this.getEmail());
         studentData.setAddress(this.getAddress());
-        studentData.setTags(this.getTags());
-        studentData.setAttendances(this.getAttendances());
+
+        studentData.setTags(new HashSet<>(this.getTags()));
+        studentData.setAttendances(new HashSet<>(this.getAttendances()));
+
         return studentData;
     }
 

--- a/src/test/java/seedu/studmap/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/AddCommandTest.java
@@ -9,12 +9,14 @@ import static seedu.studmap.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.studmap.commons.core.GuiSettings;
+import seedu.studmap.commons.core.index.Index;
 import seedu.studmap.logic.commands.exceptions.CommandException;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.ReadOnlyStudMap;
@@ -142,6 +144,11 @@ public class AddCommandTest {
 
         @Override
         public ObservableList<Student> getFilteredStudentList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public List<Index> getFilteredStudentIndices() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/studmap/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/AddTagCommandTest.java
@@ -19,7 +19,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import seedu.studmap.commons.core.Messages;
+import seedu.studmap.commons.core.index.AllIndexGenerator;
 import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.ModelManager;
 import seedu.studmap.model.StudMap;
@@ -35,11 +37,26 @@ import seedu.studmap.testutil.StudentBuilder;
 public class AddTagCommandTest {
 
     private Model model = new ModelManager(getTypicalStudMap(), new UserPrefs());
+
     private Set<Tag> singleTagSet = Stream.of(VALID_TAG_FRIEND).map(Tag::new).collect(Collectors.toSet());
-    private Set<Tag> multiTagSet = Stream.of(VALID_TAG_FRIEND, VALID_TAG_STUDENT).map(Tag::new)
-            .collect(Collectors.toSet());
-    private Set<Tag> multiTagSetReversed = Stream.of(VALID_TAG_STUDENT, VALID_TAG_FRIEND).map(Tag::new)
-            .collect(Collectors.toSet());
+    private AddTagCommand.AddTagCommandStudentEditor singleTagAdder =
+            new AddTagCommand.AddTagCommandStudentEditor(singleTagSet);
+
+    private Set<Tag> multiTagSet =
+            Stream.of(VALID_TAG_FRIEND, VALID_TAG_STUDENT).map(Tag::new).collect(Collectors.toSet());
+
+    private AddTagCommand.AddTagCommandStudentEditor multiTagAdder =
+            new AddTagCommand.AddTagCommandStudentEditor(multiTagSet);
+
+    private Set<Tag> multiTagSetReversed =
+            Stream.of(VALID_TAG_STUDENT, VALID_TAG_FRIEND).map(Tag::new).collect(Collectors.toSet());
+    private AddTagCommand.AddTagCommandStudentEditor multiTagAdderReversed =
+            new AddTagCommand.AddTagCommandStudentEditor(multiTagSetReversed);
+
+    public static void main(String[] args) {
+        AddTagCommandTest test = new AddTagCommandTest();
+        test.execute_invalidstudentIndexFilteredList_failure();
+    }
 
     @Test
     public void execute_addSingleTagUnfilteredList_success() {
@@ -52,13 +69,14 @@ public class AddTagCommandTest {
 
         Model baseModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         baseModel.setStudent(lastStudent, editedStudentBase);
-        AddTagCommand addTagCommand = new AddTagCommand(indexLaststudent, singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(indexLaststudent),
+                singleTagAdder);
 
         Model expectedModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         expectedModel.setStudent(lastStudent, editedStudentExpected);
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(singleTagSet),
+                AddTagCommand.tagSetToString(singleTagSet),
                 editedStudentBase.getName());
 
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
@@ -76,13 +94,14 @@ public class AddTagCommandTest {
 
         Model baseModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         baseModel.setStudent(lastStudent, editedStudentBase);
-        AddTagCommand addTagCommand = new AddTagCommand(indexLaststudent, multiTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(indexLaststudent),
+                multiTagAdder);
 
         Model expectedModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         expectedModel.setStudent(lastStudent, editedStudentExpected);
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(multiTagSet),
+                AddTagCommand.tagSetToString(multiTagSet),
                 editedStudentBase.getName());
 
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
@@ -99,7 +118,7 @@ public class AddTagCommandTest {
 
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_MULTI_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(singleTagSet),
+                AddTagCommand.tagSetToString(singleTagSet),
                 model.getFilteredStudentList().size());
 
         for (Student student : model.getFilteredStudentList()) {
@@ -110,7 +129,7 @@ public class AddTagCommandTest {
             expectedModel.setStudent(student, editedStudentExpected);
         }
 
-        AddTagCommand addTagCommand = new AddTagCommand(singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new AllIndexGenerator(), singleTagAdder);
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
     }
 
@@ -125,7 +144,7 @@ public class AddTagCommandTest {
 
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_MULTI_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(multiTagSet),
+                AddTagCommand.tagSetToString(multiTagSet),
                 model.getFilteredStudentList().size());
 
         for (Student student : model.getFilteredStudentList()) {
@@ -137,7 +156,7 @@ public class AddTagCommandTest {
             expectedModel.setStudent(student, editedStudentExpected);
         }
 
-        AddTagCommand addTagCommand = new AddTagCommand(multiTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new AllIndexGenerator(), multiTagAdder);
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
     }
 
@@ -152,13 +171,14 @@ public class AddTagCommandTest {
 
         Model baseModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         baseModel.setStudent(lastStudent, editedStudentBase);
-        AddTagCommand addTagCommand = new AddTagCommand(indexLaststudent, multiTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(indexLaststudent),
+                multiTagAdder);
 
         Model expectedModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         expectedModel.setStudent(lastStudent, editedStudentModel);
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(multiTagSet),
+                AddTagCommand.tagSetToString(multiTagSet),
                 editedStudentBase.getName());
 
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
@@ -175,13 +195,14 @@ public class AddTagCommandTest {
 
         Model baseModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         baseModel.setStudent(lastStudent, editedStudentBase);
-        AddTagCommand addTagCommand = new AddTagCommand(indexLaststudent, singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(indexLaststudent),
+                singleTagAdder);
 
         Model expectedModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
         expectedModel.setStudent(lastStudent, editedStudentModel);
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(singleTagSet),
+                AddTagCommand.tagSetToString(singleTagSet),
                 editedStudentBase.getName());
 
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
@@ -198,9 +219,9 @@ public class AddTagCommandTest {
         Model expectedModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
 
         String expectedMessage = String.format(
-                AddTagCommand.MESSAGE_MULTI_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(singleTagSet),
-                model.getFilteredStudentList().size());
+                AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
+                AddTagCommand.tagSetToString(singleTagSet),
+                model.getFilteredStudentList().get(0).getName());
 
         for (Student student : model.getFilteredStudentList()) {
             studentInList = new StudentBuilder(student);
@@ -211,7 +232,7 @@ public class AddTagCommandTest {
         }
 
         showStudentAtIndex(baseModel, INDEX_SECOND_STUDENT);
-        AddTagCommand addTagCommand = new AddTagCommand(singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new AllIndexGenerator(), singleTagAdder);
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
     }
 
@@ -232,11 +253,12 @@ public class AddTagCommandTest {
         expectedModel.setStudent(lastStudent, editedStudentExpected);
         String expectedMessage = String.format(
                 AddTagCommand.MESSAGE_SINGLE_ADD_TAGS_SUCCESS,
-                AddTagCommand.tagSetToSting(singleTagSet),
+                AddTagCommand.tagSetToString(singleTagSet),
                 editedStudentBase.getName());
 
         showStudentAtIndex(baseModel, INDEX_SECOND_STUDENT);
-        AddTagCommand addTagCommand = new AddTagCommand(indexLaststudent, singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(indexLaststudent),
+                singleTagAdder);
 
         assertCommandSuccess(addTagCommand, baseModel, expectedMessage, expectedModel);
     }
@@ -244,7 +266,8 @@ public class AddTagCommandTest {
     @Test
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(outOfBoundIndex),
+                singleTagAdder);
 
         assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
@@ -260,22 +283,27 @@ public class AddTagCommandTest {
         // ensures that outOfBoundIndex is still in bounds of student map list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getStudMap().getStudentList().size());
 
-        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, singleTagSet);
+        AddTagCommand addTagCommand = new AddTagCommand(new SingleIndexGenerator(outOfBoundIndex),
+                singleTagAdder);
 
         assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final AddTagCommand standardSingleCommand = new AddTagCommand(INDEX_FIRST_STUDENT, singleTagSet);
-        final AddTagCommand standardMultiCommand = new AddTagCommand(INDEX_FIRST_STUDENT, multiTagSetReversed);
+        final AddTagCommand standardSingleCommand =
+                new AddTagCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), singleTagAdder);
+        final AddTagCommand standardMultiCommand =
+                new AddTagCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), multiTagAdderReversed);
 
         // same values -> returns true
-        AddTagCommand commandWithSameValues = new AddTagCommand(INDEX_FIRST_STUDENT, singleTagSet);
+        AddTagCommand commandWithSameValues =
+                new AddTagCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), singleTagAdder);
         assertTrue(standardSingleCommand.equals(commandWithSameValues));
 
         // same values but different order -> returns true
-        AddTagCommand commandWithSameMultiValues = new AddTagCommand(INDEX_FIRST_STUDENT, multiTagSetReversed);
+        AddTagCommand commandWithSameMultiValues =
+                new AddTagCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), multiTagAdderReversed);
         assertTrue(standardMultiCommand.equals(commandWithSameMultiValues));
 
         // same object -> returns true
@@ -288,14 +316,11 @@ public class AddTagCommandTest {
         assertFalse(standardSingleCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardSingleCommand.equals(new AddTagCommand(INDEX_SECOND_STUDENT, singleTagSet)));
+        assertFalse(standardSingleCommand.equals(
+                new AddTagCommand(new SingleIndexGenerator(INDEX_SECOND_STUDENT), singleTagAdder)));
 
         // different descriptor -> returns false
-        assertFalse(standardSingleCommand.equals(new AddTagCommand(INDEX_FIRST_STUDENT, multiTagSet)));
-    }
-
-    public static void main(String[] args) {
-        AddTagCommandTest test = new AddTagCommandTest();
-        test.execute_invalidstudentIndexFilteredList_failure();
+        assertFalse(standardSingleCommand.equals(
+                new AddTagCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), multiTagAdder)));
     }
 }

--- a/src/test/java/seedu/studmap/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/studmap/logic/commands/CommandTestUtil.java
@@ -58,8 +58,8 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditCommand.EditStudentDescriptor DESC_AMY;
-    public static final EditCommand.EditStudentDescriptor DESC_BOB;
+    public static final EditCommand.EditCommandStudentEditor DESC_AMY;
+    public static final EditCommand.EditCommandStudentEditor DESC_BOB;
 
     static {
         DESC_AMY = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/studmap/logic/commands/EditCommandStudentEditorTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/EditCommandStudentEditorTest.java
@@ -12,15 +12,15 @@ import static seedu.studmap.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.studmap.logic.commands.EditCommand.EditStudentDescriptor;
+import seedu.studmap.logic.commands.EditCommand.EditCommandStudentEditor;
 import seedu.studmap.testutil.EditStudentDescriptorBuilder;
 
-public class EditStudentDescriptorTest {
+public class EditCommandStudentEditorTest {
 
     @Test
     public void equals() {
         // same values -> returns true
-        EditStudentDescriptor descriptorWithSameValues = new EditStudentDescriptor(DESC_AMY);
+        EditCommandStudentEditor descriptorWithSameValues = new EditCommandStudentEditor(DESC_AMY);
         assertTrue(DESC_AMY.equals(descriptorWithSameValues));
 
         // same object -> returns true
@@ -36,7 +36,8 @@ public class EditStudentDescriptorTest {
         assertFalse(DESC_AMY.equals(DESC_BOB));
 
         // different name -> returns false
-        EditStudentDescriptor editedAmy = new EditStudentDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();
+        EditCommandStudentEditor editedAmy =
+                new EditStudentDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different phone -> returns false

--- a/src/test/java/seedu/studmap/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/EditCommandTest.java
@@ -18,7 +18,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.studmap.commons.core.Messages;
 import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.logic.commands.EditCommand.EditStudentDescriptor;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
+import seedu.studmap.logic.commands.EditCommand.EditCommandStudentEditor;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.ModelManager;
 import seedu.studmap.model.StudMap;
@@ -37,8 +38,8 @@ public class EditCommandTest {
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Student editedStudent = new StudentBuilder().build();
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(editedStudent).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_STUDENT, descriptor);
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder(editedStudent).build();
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), editor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);
 
@@ -57,9 +58,9 @@ public class EditCommandTest {
         Student editedStudent = studentInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
 
-        EditCommand.EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB)
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLaststudent, descriptor);
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(indexLaststudent), editor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);
 
@@ -71,10 +72,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_STUDENT, new EditStudentDescriptor());
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new EditCommandStudentEditor());
         Student editedStudent = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);
+        String expectedMessage = EditCommand.MESSAGE_NOT_EDITED;
 
         Model expectedModel = new ModelManager(new StudMap(model.getStudMap()), new UserPrefs());
 
@@ -87,7 +89,7 @@ public class EditCommandTest {
 
         Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         Student editedStudent = new StudentBuilder(studentInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_STUDENT,
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);
@@ -101,10 +103,11 @@ public class EditCommandTest {
     @Test
     public void execute_duplicatestudentUnfilteredList_failure() {
         Student firstStudent = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(firstStudent).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_STUDENT, descriptor);
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder(firstStudent).build();
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(INDEX_SECOND_STUDENT),
+                editor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_STUDENT);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_STUDENT);
     }
 
     @Test
@@ -113,17 +116,17 @@ public class EditCommandTest {
 
         // edit student in filtered list into a duplicate in student map
         Student studentInList = model.getStudMap().getStudentList().get(INDEX_SECOND_STUDENT.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_STUDENT,
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new EditStudentDescriptorBuilder(studentInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_STUDENT);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_STUDENT);
     }
 
     @Test
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(outOfBoundIndex), editor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
@@ -139,7 +142,7 @@ public class EditCommandTest {
         // ensures that outOfBoundIndex is still in bounds of student map list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getStudMap().getStudentList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+        EditCommand editCommand = new EditCommand(new SingleIndexGenerator(outOfBoundIndex),
                 new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
@@ -147,11 +150,13 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_STUDENT, DESC_AMY);
+        final EditCommand standardCommand =
+                new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), DESC_AMY);
 
         // same values -> returns true
-        EditCommand.EditStudentDescriptor copyDescriptor = new EditStudentDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_STUDENT, copyDescriptor);
+        EditCommandStudentEditor copyDescriptor = new EditCommandStudentEditor(DESC_AMY);
+        EditCommand commandWithSameValues =
+                new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -164,10 +169,12 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_STUDENT, DESC_AMY)));
+        assertFalse(standardCommand.equals(
+                new EditCommand(new SingleIndexGenerator(INDEX_SECOND_STUDENT), DESC_AMY)));
 
-        // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_STUDENT, DESC_BOB)));
+        // different editor -> returns false
+        assertFalse(standardCommand.equals(
+                new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), DESC_BOB)));
     }
 
 }

--- a/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.studmap.commons.core.Messages;
 import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.ModelManager;
 import seedu.studmap.model.UserPrefs;
@@ -30,12 +31,13 @@ class MarkCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Student studentToMark = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         Attendance attendance = new Attendance("T04", true);
-        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_STUDENT, attendance);
+        MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new MarkCommand.MarkCommandStudentEditor(attendance));
 
         Student markedStudent = new StudentBuilder(studentToMark).addAttended("T04").build();
 
-        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SUCCESS,
-                attendance.getAttendance(), markedStudent);
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS,
+                attendance.getAttendanceString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), markedStudent);
@@ -48,12 +50,13 @@ class MarkCommandTest {
 
         Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         Attendance attendance = new Attendance("T04", true);
-        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_STUDENT, attendance);
+        MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new MarkCommand.MarkCommandStudentEditor(attendance));
 
         Student markedStudent = new StudentBuilder(studentInFilteredList).addAttended("T04").build();
 
-        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SUCCESS,
-                attendance.getAttendance(), markedStudent);
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS,
+                attendance.getAttendanceString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), markedStudent);
@@ -64,7 +67,8 @@ class MarkCommandTest {
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         Attendance attendance = new Attendance("T04", true);
-        MarkCommand markCommand = new MarkCommand(outOfBoundIndex, attendance);
+        MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(outOfBoundIndex),
+                new MarkCommand.MarkCommandStudentEditor(attendance));
 
         assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/studmap/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/studmap/logic/parser/CommandParserTestUtil.java
@@ -30,7 +30,7 @@ public class CommandParserTestUtil {
      */
     public static void assertParseFailure(Parser<? extends Command> parser, String userInput, String expectedMessage) {
         try {
-            parser.parse(userInput);
+            Command c = parser.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
             assertEquals(expectedMessage, pe.getMessage());

--- a/src/test/java/seedu/studmap/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/EditCommandParserTest.java
@@ -34,8 +34,9 @@ import static seedu.studmap.testutil.TypicalIndexes.INDEX_THIRD_STUDENT;
 import org.junit.jupiter.api.Test;
 
 import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.logic.commands.EditCommand;
-import seedu.studmap.logic.commands.EditCommand.EditStudentDescriptor;
+import seedu.studmap.logic.commands.EditCommand.EditCommandStudentEditor;
 import seedu.studmap.model.student.Address;
 import seedu.studmap.model.student.Email;
 import seedu.studmap.model.student.Name;
@@ -111,10 +112,10 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
 
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -124,9 +125,9 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_STUDENT;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -136,33 +137,33 @@ public class EditCommandParserTest {
         // name
         Index targetIndex = INDEX_THIRD_STUDENT;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
-        EditCommand.EditStudentDescriptor descriptor =
+        EditCommandStudentEditor editor =
                 new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
-        descriptor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        editor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
-        descriptor = new EditStudentDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        editor = new EditStudentDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // studmap
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
-        descriptor = new EditStudentDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        editor = new EditStudentDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
+        expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditStudentDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        editor = new EditStudentDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -173,10 +174,10 @@ public class EditCommandParserTest {
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -186,16 +187,16 @@ public class EditCommandParserTest {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_STUDENT;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
+        EditCommand expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
         userInput = targetIndex.getOneBased() + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
                 + PHONE_DESC_BOB;
-        descriptor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+        editor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -204,8 +205,8 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_STUDENT;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommandStudentEditor editor = new EditStudentDescriptorBuilder().withTags().build();
+        EditCommand expectedCommand = new EditCommand(new SingleIndexGenerator(targetIndex), editor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/studmap/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/MarkCommandParserTest.java
@@ -7,9 +7,9 @@ import static seedu.studmap.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.logic.commands.MarkCommand;
 import seedu.studmap.model.student.Attendance;
-
 
 
 public class MarkCommandParserTest {
@@ -19,8 +19,9 @@ public class MarkCommandParserTest {
     @Test
     public void parse_validArgs_returnUnmarkCommand() {
         String className = "T01";
-        assertParseSuccess(parser, "1 absent c/   " + className, new MarkCommand(INDEX_FIRST_STUDENT,
-                new Attendance(className, true)));
+        assertParseSuccess(parser, "1 absent c/   " + className,
+                new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                        new MarkCommand.MarkCommandStudentEditor(new Attendance(className, true))));
     }
 
     @Test

--- a/src/test/java/seedu/studmap/logic/parser/StudMapParserTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/StudMapParserTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.logic.commands.AddCommand;
 import seedu.studmap.logic.commands.ClearCommand;
 import seedu.studmap.logic.commands.DeleteCommand;
@@ -55,10 +56,11 @@ public class StudMapParserTest {
     @Test
     public void parseCommand_edit() throws Exception {
         Student student = new StudentBuilder().build();
-        EditCommand.EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(student).build();
+        EditCommand.EditCommandStudentEditor descriptor = new EditStudentDescriptorBuilder(student).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_STUDENT.getOneBased() + " " + StudentUtil.getEditstudentDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_STUDENT, descriptor), command);
+        assertEquals(new EditCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT), descriptor),
+                command);
     }
 
     @Test
@@ -90,7 +92,7 @@ public class StudMapParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/studmap/testutil/EditStudentDescriptorBuilder.java
+++ b/src/test/java/seedu/studmap/testutil/EditStudentDescriptorBuilder.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import seedu.studmap.logic.commands.EditCommand.EditStudentDescriptor;
+import seedu.studmap.logic.commands.EditCommand.EditCommandStudentEditor;
 import seedu.studmap.model.student.Address;
 import seedu.studmap.model.student.Email;
 import seedu.studmap.model.student.Name;
@@ -17,21 +17,21 @@ import seedu.studmap.model.tag.Tag;
  */
 public class EditStudentDescriptorBuilder {
 
-    private EditStudentDescriptor descriptor;
+    private EditCommandStudentEditor descriptor;
 
     public EditStudentDescriptorBuilder() {
-        descriptor = new EditStudentDescriptor();
+        descriptor = new EditCommandStudentEditor();
     }
 
-    public EditStudentDescriptorBuilder(EditStudentDescriptor descriptor) {
-        this.descriptor = new EditStudentDescriptor(descriptor);
+    public EditStudentDescriptorBuilder(EditCommandStudentEditor descriptor) {
+        this.descriptor = new EditCommandStudentEditor(descriptor);
     }
 
     /**
      * Returns an {@code EditStudentDescriptor} with fields containing {@code student}'s details
      */
     public EditStudentDescriptorBuilder(Student student) {
-        descriptor = new EditStudentDescriptor();
+        descriptor = new EditCommandStudentEditor();
         descriptor.setName(student.getName());
         descriptor.setPhone(student.getPhone());
         descriptor.setEmail(student.getEmail());
@@ -81,7 +81,7 @@ public class EditStudentDescriptorBuilder {
         return this;
     }
 
-    public EditStudentDescriptor build() {
+    public EditCommandStudentEditor build() {
         return descriptor;
     }
 }

--- a/src/test/java/seedu/studmap/testutil/StudentUtil.java
+++ b/src/test/java/seedu/studmap/testutil/StudentUtil.java
@@ -9,7 +9,7 @@ import static seedu.studmap.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 
 import seedu.studmap.logic.commands.AddCommand;
-import seedu.studmap.logic.commands.EditCommand.EditStudentDescriptor;
+import seedu.studmap.logic.commands.EditCommand.EditCommandStudentEditor;
 import seedu.studmap.model.student.Student;
 import seedu.studmap.model.tag.Tag;
 
@@ -43,7 +43,7 @@ public class StudentUtil {
     /**
      * Returns the part of command string for the given {@code EditStudentDescriptor}'s details.
      */
-    public static String getEditstudentDescriptorDetails(EditStudentDescriptor descriptor) {
+    public static String getEditstudentDescriptorDetails(EditCommandStudentEditor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));


### PR DESCRIPTION
Resolves #51.

We have a number of commands that each mutate a `Student`. This pull request abstracts that logic.

`EditCommand` has two execution methods `execute` and `executeNoRefresh` which have duplicated code, although `executeNoRefresh` has functionality which is a subset of that of `execute`. Let's make `execute` invoke `executeNoRefresh` for the overlapped behaviour. This behaviour will be translated to the unification described below.

- Add 'IndexCommandParser<T extends Command>' parser interface with a default `parse` implementation that abstracts the idea of a command that reads and parses an index. `parse` invokes a `getIndexCommand(ArgumentMultimap, IndexListGenerator)` to produce a command using these fields.
- `IndexCommandParser` additionally has `validatePreamble()` method, optionally overridden by commands that require stricter validation.
- Add abstract `EditStudentCommand<T extends StudentEditor>`, which is the generalized form of a command that edits students. It takes in a `StudentEditor` which promises a method for editing a `Student`, and a method for checking if it will perform any edits.
- Add `EditStudentCommandParser<S extends StudentEditor>` that parses a `EditStudentCommand<S>`, and automatically throws parse exceptions if no edits are made.
- Add `IndexGenerator` class which implements `Function<Model, List<Index>>` which produces a list of indices for a command to act upon.
- Add `AllIndexGenerator` which generates a list of all currently shown indices.
- Add `SingleIndexGenerator` which generates a list containing a single index.
- Update `EditCommand`, `EditCommandParser`, `AddTagCommand`, `AddTagCommandParser`, `MarkCommand`, `MarkCommandParser` to use the abovementioned paradigm.

- Add some parser utilities to separate preamble into separate parts.
- Add `MESSAGE_DUPLICATE_STUDENT` to `Messages`