### PR TITLE
Add assignment feature

### DIFF
--- a/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import seedu.studmap.MainApp;
 import seedu.studmap.commons.core.LogsCenter;
 import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.logic.commands.commons.StudentEditor;

--- a/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/AddTagCommand.java
@@ -22,7 +22,7 @@ import seedu.studmap.model.tag.Tag;
  */
 public class AddTagCommand extends EditStudentCommand<AddTagCommand.AddTagCommandStudentEditor> {
 
-    public static final Logger LOGGER = LogsCenter.getLogger(MainApp.class);
+    public static final Logger LOGGER = LogsCenter.getLogger(AddTagCommand.class);
 
     public static final String COMMAND_WORD = "addtag";
 

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -1,7 +1,7 @@
 package seedu.studmap.logic.commands;
 
-import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
+import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
 
 import java.util.HashSet;
 import java.util.List;
@@ -46,7 +46,7 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     public static final String MESSAGE_MARK_MULTI_SUCCESS_ASSIGNMENT =
             "Marked assignment %1$s as %2$s for %3$s students: ";
 
-    public static final String MESSAGE_NO_EDIT = "Attendance or assignment status must be provided.";
+    public static final String MESSAGE_NO_EDIT = "Attendance or Assignment must be provided.";
 
     public MarkCommand(IndexListGenerator indexListGenerator, MarkCommandStudentEditor studentEditor) {
         super(indexListGenerator, studentEditor);
@@ -167,6 +167,18 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
 
             // state check
             MarkCommand.MarkCommandStudentEditor e = (MarkCommand.MarkCommandStudentEditor) other;
+
+            if (getAttendance() == null && e.getAttendance() != null) {
+                return false;
+            } else if (getAttendance() == null && e.getAttendance() == null) {
+                return true;
+            }
+
+            if (getAssignment() == null && e.getAssignment() != null) {
+                return false;
+            } else if (getAssignment() == null && e.getAssignment() == null) {
+                return true;
+            }
 
             return getAttendance().equals(e.getAttendance()) && getAssignment().equals(e.getAssignment());
         }

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -92,7 +92,7 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     }
 
     /**
-     * A static StudentEditor that adjusts Attendance for a given Student.
+     * A static StudentEditor that adjusts Attendance or Assignment for a given Student.
      */
     public static class MarkCommandStudentEditor implements StudentEditor {
 

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -134,10 +134,12 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
 
             if (attendance != null) {
                 Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
+                newAttendance.remove(attendance);
                 newAttendance.add(attendance);
                 studentData.setAttendances(newAttendance);
             } else if (assignment != null) {
                 Set<Assignment> newAssignments = new HashSet<>(studentToEdit.getAssignments());
+                newAssignments.remove(assignment);
                 newAssignments.add(assignment);
                 studentData.setAssignments(newAssignments);
             }

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -1,6 +1,7 @@
 package seedu.studmap.logic.commands;
 
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
+import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
 
 import java.util.HashSet;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Set;
 
 import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.logic.commands.commons.StudentEditor;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Student;
 import seedu.studmap.model.student.StudentData;
@@ -20,18 +22,31 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     public static final String COMMAND_WORD = "mark";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Marks the attendance for student identified by the index number used in the displayed"
-            + " student list.\n Marks attendance for the class or tutorial specified in the parameter.\n"
-            + "Parameters: INDEX (must be positive integer or use \"all\" to mark everyone currently displayed)"
+            + ": Marks the status for a student identified by the index number used in the displayed"
+            + " student list.\nThis command support both attendance and assignment marking."
+            + "\n<Attendance>"
+            + "\n  Marks attendance for the class or tutorial specified in the parameter."
+            + "\n  Parameters: INDEX (must be positive integer or use \"all\" to mark everyone currently displayed)"
             + " OPTION (must be absent/present) "
-            + PREFIX_CLASS + " [CLASS]\n"
-            + "Example: " + COMMAND_WORD + " 1 present " + PREFIX_CLASS + "T01\n"
-            + "Example: " + COMMAND_WORD + " all present " + PREFIX_CLASS + "T07";
+            + PREFIX_CLASS + " [CLASS]"
+            + "\n Example: " + COMMAND_WORD + " 1 present " + PREFIX_CLASS + "T01"
+            + "\n Example: " + COMMAND_WORD + " all present " + PREFIX_CLASS + "T07"
+            + "\n\n<Assignment>"
+            + "\n Marks the status for the assignment specified in the parameter.\n"
+            + "Parameters: INDEX (must be positive integer or use \"all\" to mark everyone currently displayed)"
+            + " OPTION (must be marked/received/new where 'new' also represents an unmarked assignment) "
+            + PREFIX_ASSIGNMENT + " [CLASS]\n"
+            + "Example: " + COMMAND_WORD + " 1 new " + PREFIX_ASSIGNMENT + "A01\n"
+            + "Example: " + COMMAND_WORD + " all marked " + PREFIX_ASSIGNMENT + "A07";;
 
-    public static final String MESSAGE_MARK_SINGLE_SUCCESS = "Marked Student as %1$s: %2$s";
-    public static final String MESSAGE_MARK_MULTI_SUCCESS = "Marked %1$s students as %2$s";
+    public static final String MESSAGE_MARK_SINGLE_SUCCESS_ATTENDACE = "Marked Student as %1$s: %2$s";
+    public static final String MESSAGE_MARK_MULTI_SUCCESS_ATTENDACE = "Marked %1$s students as %2$s";
+    public static final String MESSAGE_MARK_SINGLE_SUCCESS_ASSIGNMENT =
+            "Marked assignment %1$s for student %2$s as %3$s:" + " \n%4$s";
+    public static final String MESSAGE_MARK_MULTI_SUCCESS_ASSIGNMENT =
+            "Marked assignment %1$s as %2$s for %3$s students: ";
 
-    public static final String MESSAGE_NO_EDIT = "Attendance must be provided.";
+    public static final String MESSAGE_NO_EDIT = "Attendance or assignment status must be provided.";
 
     public MarkCommand(IndexListGenerator indexListGenerator, MarkCommandStudentEditor studentEditor) {
         super(indexListGenerator, studentEditor);
@@ -39,13 +54,36 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
 
     @Override
     public String getSingleEditSuccessMessage(Student editedStudent) {
-        return String.format(MESSAGE_MARK_SINGLE_SUCCESS, studentEditor.getAttendance().getAttendanceString(),
-                editedStudent);
+        if (studentEditor.getAttendance() != null) {
+            assert studentEditor.getAssignment() == null : "Assignment should not be marked if attendance is marked";
+            return String.format(MESSAGE_MARK_SINGLE_SUCCESS_ATTENDACE,
+                    studentEditor.getAttendance().getAttendanceString(),
+                    editedStudent);
+        } else {
+            assert studentEditor.getAssignment() == null : "Attendance should not be marked if assignment is marked";
+            Assignment assignment = studentEditor.getAssignment();
+            return String.format(MESSAGE_MARK_SINGLE_SUCCESS_ASSIGNMENT,
+                    assignment.getAssignmentName(),
+                    editedStudent.getName(),
+                    assignment.getAssignmentString(),
+                    editedStudent);
+        }
     }
 
     @Override
     public String getMultiEditSuccessMessage(List<Student> editedStudents) {
-        return String.format(MESSAGE_MARK_MULTI_SUCCESS, editedStudents.size(), studentEditor.getAttendance());
+        if (studentEditor.getAttendance() != null) {
+            assert studentEditor.getAssignment() == null : "Assignment should not be marked if attendance is marked";
+            return String.format(MESSAGE_MARK_MULTI_SUCCESS_ATTENDACE,
+                    editedStudents.size(), studentEditor.getAttendance());
+        } else {
+            assert studentEditor.getAssignment() == null : "Attendance should not be marked if assignment is marked";
+            Assignment assignment = studentEditor.getAssignment();
+            return String.format(MESSAGE_MARK_MULTI_SUCCESS_ASSIGNMENT,
+                    assignment.getAssignmentName(),
+                    assignment.getAssignmentString(),
+                    editedStudents.size());
+        }
     }
 
     @Override
@@ -59,6 +97,7 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     public static class MarkCommandStudentEditor implements StudentEditor {
 
         private final Attendance attendance;
+        private final Assignment assignment;
 
         /**
          * Constructor using Attendance.
@@ -66,26 +105,49 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
          * @param attendance Attendance to edit the student with.
          */
         public MarkCommandStudentEditor(Attendance attendance) {
+            this.assignment = null;
             this.attendance = attendance;
+        }
+
+        /**
+         * Constructor using Assignment.
+         *
+         * @param assignment Assignment to edit the student with.
+         */
+        public MarkCommandStudentEditor(Assignment assignment) {
+            this.assignment = assignment;
+            this.attendance = null;
         }
 
         public Attendance getAttendance() {
             return attendance;
         }
 
+        public Assignment getAssignment() {
+            return assignment;
+        }
+
+
         @Override
         public Student editStudent(Student studentToEdit) {
             StudentData studentData = studentToEdit.getStudentData();
 
-            Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
-            newAttendance.add(attendance);
-            studentData.setAttendances(newAttendance);
+            if (attendance != null) {
+                Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
+                newAttendance.add(attendance);
+                studentData.setAttendances(newAttendance);
+            } else if (assignment != null) {
+                Set<Assignment> newAssignments = new HashSet<>(studentToEdit.getAssignments());
+                newAssignments.add(assignment);
+                studentData.setAssignments(newAssignments);
+            }
+
             return new Student(studentData);
         }
 
         @Override
         public boolean hasEdits() {
-            return attendance != null;
+            return attendance != null || assignment != null;
         }
 
         @Override
@@ -104,7 +166,7 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
             // state check
             MarkCommand.MarkCommandStudentEditor e = (MarkCommand.MarkCommandStudentEditor) other;
 
-            return getAttendance().equals(e.getAttendance());
+            return getAttendance().equals(e.getAttendance()) && getAssignment().equals(e.getAssignment());
         }
     }
 }

--- a/src/main/java/seedu/studmap/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UnmarkCommand.java
@@ -1,18 +1,14 @@
 package seedu.studmap.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
-import static seedu.studmap.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import seedu.studmap.commons.core.Messages;
-import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.logic.commands.exceptions.CommandException;
-import seedu.studmap.model.Model;
+import seedu.studmap.commons.core.index.IndexListGenerator;
+import seedu.studmap.logic.commands.commons.StudentEditor;
 import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Student;
@@ -21,7 +17,7 @@ import seedu.studmap.model.student.StudentData;
 /**
  * Unmarks the specified attendance record from the student identified using its displayed index.
  */
-public class UnmarkCommand extends Command {
+public class UnmarkCommand extends EditStudentCommand<UnmarkCommand.UnmarkCommandStudentEditor> {
 
     public static final String COMMAND_WORD = "unmark";
 
@@ -37,98 +33,148 @@ public class UnmarkCommand extends Command {
             + "\n Removes the specified assignment.\n"
             + "Parameters: INDEX (must be positive integer) "
             + PREFIX_ASSIGNMENT + " [CLASS]"
-            + "\n Example: " + COMMAND_WORD + " 1 " + PREFIX_ASSIGNMENT + " A01";;
+            + "\n Example: " + COMMAND_WORD + " 1 " + PREFIX_ASSIGNMENT + " A01";
 
-    public static final String MESSAGE_UNMARK_ATTENDANCE_SUCCESS = "Removed Class %1$s from Student: %2$s";
+    public static final String MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS = "Removed Class %1$s from Student: %2$s";
+    public static final String MESSAGE_UNMARK_SINGLE_ASSIGNMENT_SUCCESS = "Removed Assignment %1$s from Student: %2$s";
+
+    public static final String MESSAGE_UNMARK_MULTI_ATTENDANCE_SUCCESS = "Removed Class %1$s from %2$s students";
+    public static final String MESSAGE_UNMARK_MULTI_ASSIGNMENT_SUCCESS = "Removed Assignment %1$s from %2$s Students";
+
     public static final String MESSAGE_UNMARK_ATTENDANCE_NOTFOUND = "Class %1$s not found in Student: %2$s";
-    public static final String MESSAGE_UNMARK_ASSIGNMENT_SUCCESS = "Removed assignment %1$s from Student:\n%2$s";
-    public static final String MESSAGE_UNMARK_ASSIGNMENT_NOTFOUND = "Assignment %1$s not found in Student:\n%2$s";
+    public static final String MESSAGE_UNMARK_ASSIGNMENT_NOTFOUND = "Assignment %1$s not found in Student: %2$s";
 
     public static final String MESSAGE_NO_EDIT = "Attendance or Assignment must be provided.";
 
-    private final Index index;
-    private final Attendance attendance;
-    private final Assignment assignment;
-
-    /**
-     * @param index Index of the student in the filtered student list to remove the attendance
-     * @param attendance Attendance of the student to be removed
-     */
-    public UnmarkCommand(Index index, Attendance attendance) {
-        this.index = index;
-        this.attendance = attendance;
-        this.assignment = null;
+    public UnmarkCommand(IndexListGenerator indexListGenerator, UnmarkCommandStudentEditor studentEditor) {
+        super(indexListGenerator, studentEditor);
     }
-
-    /**
-     * @param index Index of the student in the filtered student list to remove the assignment
-     * @param attendance Assignment of the student to be removed
-     */
-    public UnmarkCommand(Index index, Assignment assignment) {
-        this.index = index;
-        this.attendance = null;
-        this.assignment = assignment;
-    }
-
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-
-        List<Student> lastShownList = model.getFilteredStudentList();
-
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
-        }
-
-        Student studentToEdit = lastShownList.get(index.getZeroBased());
-        StudentData studentData = studentToEdit.getStudentData();
-
-        if (attendance != null) {
-            assert assignment == null : "Assignment cannot be removed when unmarking attedance";
-            Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
-            boolean isRemoved = newAttendance.remove(attendance);
-            studentData.setAttendances(newAttendance);
-            Student editedStudent = new Student(studentData);
-
-            model.setStudent(studentToEdit, editedStudent);
-            model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-
-            return new CommandResult(
-                    String.format(isRemoved ? MESSAGE_UNMARK_ATTENDANCE_SUCCESS : MESSAGE_UNMARK_ATTENDANCE_NOTFOUND,
-                            attendance.className, editedStudent));
+    public String getSingleEditSuccessMessage(Student editedStudent) {
+        if (studentEditor.getAttendance() != null) {
+            assert studentEditor.getAssignment() == null : "Assignment should not be marked if attendance is marked";
+            return String.format(MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS,
+                    studentEditor.getAttendance().className,
+                    editedStudent);
         } else {
-            assert assignment != null && attendance == null : "Attendance cannot be removed when unmarking assignment";
-            Set<Assignment> newAssignments = new HashSet<>(studentToEdit.getAssignments());
-            boolean isRemoved = newAssignments.remove(assignment);
-            studentData.setAssignments(newAssignments);
-            Student editedStudent = new Student(studentData);
-
-            model.setStudent(studentToEdit, editedStudent);
-            model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
-
-            return new CommandResult(
-                    String.format(isRemoved ? MESSAGE_UNMARK_ASSIGNMENT_SUCCESS : MESSAGE_UNMARK_ASSIGNMENT_NOTFOUND,
-                            assignment.assignmentName, editedStudent));
+            assert studentEditor.getAttendance() == null : "Attendance should not be marked if assignment is marked";
+            Assignment assignment = studentEditor.getAssignment();
+            return String.format(MESSAGE_UNMARK_SINGLE_ASSIGNMENT_SUCCESS,
+                    assignment.getAssignmentName(),
+                    editedStudent);
         }
-
     }
 
     @Override
-    public boolean equals(Object other) {
-        // short circuit if same object
-        if (other == this) {
-            return true;
+    public String getMultiEditSuccessMessage(List<Student> editedStudents) {
+        if (studentEditor.getAttendance() != null) {
+            assert studentEditor.getAssignment() == null : "Assignment should not be marked if attendance is marked";
+            return String.format(MESSAGE_UNMARK_MULTI_ATTENDANCE_SUCCESS,
+                    studentEditor.getAttendance().className,
+                    editedStudents.size());
+        } else {
+            assert studentEditor.getAssignment() == null : "Attendance should not be marked if assignment is marked";
+            Assignment assignment = studentEditor.getAssignment();
+            return String.format(MESSAGE_UNMARK_MULTI_ASSIGNMENT_SUCCESS,
+                    assignment.getAssignmentName(),
+                    editedStudents.size());
+        }
+    }
+
+    @Override
+    public String getNoEditMessage() {
+        return MESSAGE_NO_EDIT;
+    }
+
+    /**
+     * A static StudentEditor that adjusts Attendance or Assignment for a given Student.
+     */
+    public static class UnmarkCommandStudentEditor implements StudentEditor {
+
+        private final Attendance attendance;
+        private final Assignment assignment;
+
+        /**
+         * Constructor using Attendance.
+         *
+         * @param attendance Attendance to edit the student with.
+         */
+        public UnmarkCommandStudentEditor(Attendance attendance) {
+            this.assignment = null;
+            this.attendance = attendance;
         }
 
-        // instanceof handles nulls
-        if (!(other instanceof UnmarkCommand)) {
-            return false;
+        /**
+         * Constructor using Assignment.
+         *
+         * @param assignment Assignment to edit the student with.
+         */
+        public UnmarkCommandStudentEditor(Assignment assignment) {
+            this.assignment = assignment;
+            this.attendance = null;
         }
 
-        // state check
-        UnmarkCommand e = (UnmarkCommand) other;
-        return index.equals(e.index)
-                && attendance.equals(e.attendance);
+        public Attendance getAttendance() {
+            return attendance;
+        }
+
+        public Assignment getAssignment() {
+            return assignment;
+        }
+
+
+        @Override
+        public Student editStudent(Student studentToEdit) {
+            StudentData studentData = studentToEdit.getStudentData();
+
+            if (attendance != null) {
+                Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
+                newAttendance.remove(attendance);
+                studentData.setAttendances(newAttendance);
+            } else if (assignment != null) {
+                Set<Assignment> newAssignments = new HashSet<>(studentToEdit.getAssignments());
+                newAssignments.remove(assignment);
+                studentData.setAssignments(newAssignments);
+            }
+
+            return new Student(studentData);
+        }
+
+        @Override
+        public boolean hasEdits() {
+            return attendance != null || assignment != null;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof UnmarkCommand.UnmarkCommandStudentEditor)) {
+                return false;
+            }
+
+            // state check
+            UnmarkCommand.UnmarkCommandStudentEditor e = (UnmarkCommand.UnmarkCommandStudentEditor) other;
+
+            if (getAttendance() == null && e.getAttendance() != null) {
+                return false;
+            } else if (getAttendance() == null && e.getAttendance() == null) {
+                return true;
+            }
+
+            if (getAssignment() == null && e.getAssignment() != null) {
+                return false;
+            } else if (getAssignment() == null && e.getAssignment() == null) {
+                return true;
+            }
+
+            return getAttendance().equals(e.getAttendance()) && getAssignment().equals(e.getAssignment());
+        }
     }
 }

--- a/src/main/java/seedu/studmap/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/studmap/logic/parser/CliSyntax.java
@@ -13,5 +13,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CLASS = new Prefix("c/");
     public static final Prefix PREFIX_ATTRIBUTE = new Prefix("a/");
-
+    public static final Prefix PREFIX_ASSIGNMENT = new Prefix("a/");
 }

--- a/src/main/java/seedu/studmap/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/MarkCommandParser.java
@@ -1,14 +1,10 @@
 package seedu.studmap.logic.parser;
 
 import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
+import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
 import static seedu.studmap.logic.parser.ParserUtil.separatePreamble;
 
-import java.util.logging.Logger;
-
-import seedu.studmap.MainApp;
-import seedu.studmap.commons.core.LogsCenter;
 import seedu.studmap.commons.core.index.IndexListGenerator;
 import seedu.studmap.commons.exceptions.IllegalValueException;
 import seedu.studmap.logic.commands.EditStudentCommand;
@@ -57,8 +53,8 @@ public class MarkCommandParser extends EditStudentCommandParser<MarkCommand.Mark
 
         if (argMultimap.getValue(PREFIX_CLASS).isPresent()
                 && argMultimap.getValue(PREFIX_ASSIGNMENT).isPresent()) {
-                    throw new ParseException(MESSAGE_INVALID_DOUBLE_MARK);
-                }
+            throw new ParseException(MESSAGE_INVALID_DOUBLE_MARK);
+        }
 
         if (argMultimap.getValue(PREFIX_CLASS).isPresent()) {
             String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).orElse(""));
@@ -69,8 +65,8 @@ public class MarkCommandParser extends EditStudentCommandParser<MarkCommand.Mark
             String assignmentName = ParserUtil.parseAssignmentName(
                     argMultimap.getValue(PREFIX_ASSIGNMENT).orElse(""));
             Assignment.Status markingStatus = parseStatus(preamble[1]);
-                    Assignment assignment = new Assignment(assignmentName, markingStatus);
-                    editor = new MarkCommand.MarkCommandStudentEditor(assignment);
+            Assignment assignment = new Assignment(assignmentName, markingStatus);
+            editor = new MarkCommand.MarkCommandStudentEditor(assignment);
         }
 
         assert editor != null : "Only the attendance or the assignment can be mark in the same command";

--- a/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
@@ -11,6 +11,7 @@ import seedu.studmap.commons.util.StringUtil;
 import seedu.studmap.logic.parser.exceptions.ParseException;
 import seedu.studmap.model.order.Order;
 import seedu.studmap.model.student.Address;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Email;
 import seedu.studmap.model.student.Name;
@@ -144,6 +145,21 @@ public class ParserUtil {
             throw new ParseException(Attendance.MESSAGE_CONSTRAINTS);
         }
         return trimmedClass;
+    }
+
+    /**
+     * Parses a {@code String assignmentName} checking for any errors.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code assignmentName} is invalid.
+     */
+    public static String parseAssignmentName(String assignmentName) throws ParseException {
+        requireNonNull(assignmentName);
+        String trimmedAssignment= assignmentName.trim();
+        if (!Assignment.isValidAssignmentName(trimmedAssignment)) {
+            throw new ParseException(Assignment.MESSAGE_CONSTRAINTS);
+        }
+        return trimmedAssignment;
     }
 
     /**

--- a/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
@@ -155,7 +155,7 @@ public class ParserUtil {
      */
     public static String parseAssignmentName(String assignmentName) throws ParseException {
         requireNonNull(assignmentName);
-        String trimmedAssignment= assignmentName.trim();
+        String trimmedAssignment = assignmentName.trim();
         if (!Assignment.isValidAssignmentName(trimmedAssignment)) {
             throw new ParseException(Assignment.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/studmap/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/UnmarkCommandParser.java
@@ -1,12 +1,11 @@
 package seedu.studmap.logic.parser;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
 
-import seedu.studmap.commons.core.index.Index;
-import seedu.studmap.commons.exceptions.IllegalValueException;
+import seedu.studmap.commons.core.index.IndexListGenerator;
+import seedu.studmap.logic.commands.EditStudentCommand;
 import seedu.studmap.logic.commands.UnmarkCommand;
 import seedu.studmap.logic.parser.exceptions.ParseException;
 import seedu.studmap.model.student.Assignment;
@@ -15,34 +14,54 @@ import seedu.studmap.model.student.Attendance;
 /**
  * Parses input arguments and creates a new UnmarkCommand object
  */
-public class UnmarkCommandParser implements Parser<UnmarkCommand> {
+public class UnmarkCommandParser extends EditStudentCommandParser<UnmarkCommand.UnmarkCommandStudentEditor> {
+
+    public static final String MESSAGE_INVALID_DOUBLE_MARK =
+            "Only the attendance or assignment can be unmarked in a single command";
 
     /**
      * Parses the given {@code String} of arguments in the context of the UnmarkCommand
      * and returns an UnmarkCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
-    public UnmarkCommand parse(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_CLASS, PREFIX_ASSIGNMENT);
+    @Override
+    public EditStudentCommand<UnmarkCommand.UnmarkCommandStudentEditor> getIndexCommand(
+        ArgumentMultimap argMultimap, IndexListGenerator indexListGenerator) throws ParseException {
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    UnmarkCommand.MESSAGE_USAGE));
+        String[] preamble = argMultimap.getPreamble().split("\\s+");
+        if (preamble.length != 1) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+        }
+
+        UnmarkCommand.UnmarkCommandStudentEditor editor = null;
+
+        if (argMultimap.getValue(PREFIX_CLASS).isPresent()
+                && argMultimap.getValue(PREFIX_ASSIGNMENT).isPresent()) {
+            throw new ParseException(MESSAGE_INVALID_DOUBLE_MARK);
         }
 
         if (argMultimap.getValue(PREFIX_CLASS).isPresent()) {
-            String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).get());
-            return new UnmarkCommand(index, new Attendance(className, true));
+            String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).orElse(""));
+            Attendance attendance = new Attendance(className, true);
+            editor = new UnmarkCommand.UnmarkCommandStudentEditor(attendance);
+        } else if (argMultimap.getValue(PREFIX_ASSIGNMENT).isPresent()) {
+            String assignmentName = ParserUtil.parseAssignmentName(
+                    argMultimap.getValue(PREFIX_ASSIGNMENT).orElse(""));
+            Assignment assignment = new Assignment(assignmentName, Assignment.Status.NEW);
+            editor = new UnmarkCommand.UnmarkCommandStudentEditor(assignment);
         }
-        if (argMultimap.getValue(PREFIX_ASSIGNMENT).isPresent()) {
-            String assignmentName = ParserUtil.parseAssignmentName(argMultimap.getValue(PREFIX_ASSIGNMENT).get());
-            return new UnmarkCommand(index, new Assignment(assignmentName, Assignment.Status.NEW));
-        }
-        throw new ParseException(UnmarkCommand.MESSAGE_NO_EDIT);
+
+        return new UnmarkCommand(indexListGenerator, editor);
+    }
+
+    @Override
+    public Prefix[] getPrefixes() {
+        return new Prefix[]{PREFIX_CLASS, PREFIX_ASSIGNMENT};
+    }
+
+    @Override
+    public String getUsageMessage() {
+        return UnmarkCommand.MESSAGE_USAGE;
     }
 }

--- a/src/main/java/seedu/studmap/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/UnmarkCommandParser.java
@@ -2,12 +2,14 @@ package seedu.studmap.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.studmap.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
 import static seedu.studmap.logic.parser.CliSyntax.PREFIX_CLASS;
 
 import seedu.studmap.commons.core.index.Index;
 import seedu.studmap.commons.exceptions.IllegalValueException;
 import seedu.studmap.logic.commands.UnmarkCommand;
 import seedu.studmap.logic.parser.exceptions.ParseException;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 
 /**
@@ -23,7 +25,7 @@ public class UnmarkCommandParser implements Parser<UnmarkCommand> {
     public UnmarkCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_CLASS);
+                PREFIX_CLASS, PREFIX_ASSIGNMENT);
 
         Index index;
         try {
@@ -33,9 +35,14 @@ public class UnmarkCommandParser implements Parser<UnmarkCommand> {
                     UnmarkCommand.MESSAGE_USAGE));
         }
 
-        String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).orElse(""));
-        Attendance attendance = new Attendance(className, true);
-
-        return new UnmarkCommand(index, attendance);
+        if (argMultimap.getValue(PREFIX_CLASS).isPresent()) {
+            String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).get());
+            return new UnmarkCommand(index, new Attendance(className, true));
+        }
+        if (argMultimap.getValue(PREFIX_ASSIGNMENT).isPresent()) {
+            String assignmentName = ParserUtil.parseAssignmentName(argMultimap.getValue(PREFIX_ASSIGNMENT).get());
+            return new UnmarkCommand(index, new Assignment(assignmentName, Assignment.Status.NEW));
+        }
+        throw new ParseException(UnmarkCommand.MESSAGE_NO_EDIT);
     }
 }

--- a/src/main/java/seedu/studmap/model/student/Assignment.java
+++ b/src/main/java/seedu/studmap/model/student/Assignment.java
@@ -1,0 +1,127 @@
+package seedu.studmap.model.student;
+
+import static seedu.studmap.commons.util.AppUtil.checkArgument;
+import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.studmap.commons.exceptions.IllegalValueException;
+
+/**
+ * Represents an Assignment object in StudMap.
+ * Guarantees: immutable; name is valid as declared in {@link #isValidAssignmentName(String)}
+ */
+public class Assignment {
+
+    public static final String MESSAGE_CONSTRAINTS = "Assignment names should consist of "
+            + "alphanumerics, space, dash and underscore";
+    public static final String MESSAGE_STATUS_CONSTRAINTS = "Assignment marking status should be one of "
+            + "new, received or marked";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum} \\-_]+";
+    /**
+     * Reprents the possible status the assignment can take.
+     */
+    public static enum Status {
+        MARKED,
+        RECEIVED,
+        NEW
+    }
+    public static final String ASSIGNMENT_MARKED = "marked";
+    public static final String ASSIGNMENT_RECEIVED = "received";
+    public static final String ASSIGNMENT_NEW = "new";
+
+    public final String assignmentName;
+    public final Status markingStatus;
+
+    /**
+     * Constructs an {@code Assignment} object.
+     *
+     * @param assignmentName A valid assignment name.
+     * @param markingStatus A status representing whether the assignment has been marked
+     */
+    public Assignment(String assignmentName, Status markingStatus) {
+        requireAllNonNull(assignmentName, markingStatus);
+        checkArgument(isValidAssignmentName(assignmentName), MESSAGE_CONSTRAINTS);
+        this.assignmentName = assignmentName;
+        this.markingStatus = markingStatus;
+    }
+
+    /**
+     * Returns true if a given string is a valid assignment name.
+     */
+    public static boolean isValidAssignmentName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if the given string is a valid marking status.
+     */
+    public static boolean isValidMarkingStatus(String test) {
+        return test.equals(ASSIGNMENT_MARKED)
+                || test.equals(ASSIGNMENT_RECEIVED)
+                || test.equals(ASSIGNMENT_NEW);
+    }
+
+    /**
+     * Converts the status of the assignment to string.
+     */
+    public static String statusToString(Status status) {
+        switch (status) {
+        case MARKED:
+            return ASSIGNMENT_MARKED;
+        case RECEIVED:
+            return ASSIGNMENT_RECEIVED;
+        default:
+            return ASSIGNMENT_NEW;
+        }
+    }
+
+    /**
+     * Converts a string to the assignment status.
+     */
+    public static Status stringToStatus(String statusString) throws IllegalValueException {
+        statusString = statusString.toLowerCase();
+        switch (statusString) {
+        case ASSIGNMENT_MARKED:
+            return Status.MARKED;
+        case ASSIGNMENT_RECEIVED:
+            return Status.RECEIVED;
+        case ASSIGNMENT_NEW:
+            return Status.NEW;
+        default:
+            throw new IllegalValueException(MESSAGE_STATUS_CONSTRAINTS);
+        }
+    }
+
+    public String getString() {
+        return assignmentName + ':' + statusToString(markingStatus);
+    }
+
+    public String getAssignmentString() {
+        return statusToString(markingStatus);
+    }
+
+    public String getAssignmentName() {
+        return assignmentName;
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Assignment // instanceof handles nulls
+                && assignmentName.equals(((Assignment) other).assignmentName)); // state check
+                // no check for markingStatus to ensure only one assignment record per assignmentName
+    }
+
+    @Override
+    public int hashCode() {
+        return assignmentName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + getString() + ']';
+    }
+
+}

--- a/src/main/java/seedu/studmap/model/student/Student.java
+++ b/src/main/java/seedu/studmap/model/student/Student.java
@@ -24,17 +24,19 @@ public class Student {
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Attendance> attendances = new HashSet<>();
+    private final Set<Assignment> assignments = new HashSet<>();
 
     /**
      * Constructor using a StudentData parameter object.
-     * Requires name, phone, email, studmap, tags to be non-null.
+     * Requires name, phone, email, studmap, tags, attendances and assignments to be non-null.
      *
      * @param studentData StudentData parameter object.
      */
     public Student(StudentData studentData) {
         requireAllNonNull(studentData.getName(), studentData.getPhone(),
                 studentData.getEmail(), studentData.getAddress(),
-                studentData.getTags(), studentData.getAttendances());
+                studentData.getTags(), studentData.getAttendances(),
+                studentData.getAssignments());
 
         this.name = studentData.getName();
         this.phone = studentData.getPhone();
@@ -42,6 +44,7 @@ public class Student {
         this.address = studentData.getAddress();
         this.tags.addAll(studentData.getTags());
         this.attendances.addAll(studentData.getAttendances());
+        this.assignments.addAll(studentData.getAssignments());
     }
 
     public Name getName() {
@@ -92,6 +95,14 @@ public class Student {
         return Collections.unmodifiableSet(attendances);
     }
 
+    /**
+     * Returns an immutable Assignment set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Assignment> getAssignments() {
+        return Collections.unmodifiableSet(assignments);
+    }
+
     public StudentData getStudentData() {
 
         StudentData studentData = new StudentData();
@@ -103,6 +114,7 @@ public class Student {
 
         studentData.setTags(new HashSet<>(this.getTags()));
         studentData.setAttendances(new HashSet<>(this.getAttendances()));
+        studentData.setAssignments(new HashSet<>(this.getAssignments()));
 
         return studentData;
     }
@@ -148,13 +160,14 @@ public class Student {
                 && otherStudent.getEmail().equals(getEmail())
                 && otherStudent.getAddress().equals(getAddress())
                 && otherStudent.getTags().equals(getTags())
-                && otherStudent.getAttendances().equals(getAttendances());
+                && otherStudent.getAttendances().equals(getAttendances())
+                && otherStudent.getAssignments().equals(getAssignments());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags, attendances);
+        return Objects.hash(name, phone, email, address, tags, attendances, assignments);
     }
 
     @Override
@@ -173,6 +186,12 @@ public class Student {
         if (!attendances.isEmpty()) {
             builder.append("; Attendance: ");
             attendances.forEach(builder::append);
+        }
+
+        Set<Assignment> assignments = getAssignments();
+        if (!assignments.isEmpty()) {
+            builder.append("; Assignment: ");
+            assignments.forEach(builder::append);
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/studmap/model/student/StudentData.java
+++ b/src/main/java/seedu/studmap/model/student/StudentData.java
@@ -16,6 +16,7 @@ public class StudentData {
     private Address address;
     private Set<Tag> tags = new HashSet<>();
     private Set<Attendance> attendances = new HashSet<>();
+    private Set<Assignment> assignments = new HashSet<>();
 
     public Name getName() {
         return name;
@@ -65,8 +66,20 @@ public class StudentData {
         this.attendances.addAll(attendances);
     }
 
+    public void setAssignments(Set<Assignment> assignments) {
+        this.assignments = assignments;
+    }
+
+    public void addAssignments(Set<Assignment> assignments) {
+        this.assignments.addAll(assignments);
+    }
+
     public Set<Attendance> getAttendances() {
         return attendances;
+    }
+
+    public Set<Assignment> getAssignments() {
+        return assignments;
     }
 
     @Override
@@ -83,11 +96,12 @@ public class StudentData {
                 && Objects.equals(email, that.email)
                 && Objects.equals(address, that.address)
                 && Objects.equals(tags, that.tags)
-                && Objects.equals(attendances, that.attendances);
+                && Objects.equals(attendances, that.attendances)
+                && Objects.equals(assignments, that.assignments);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, phone, email, address, tags, attendances);
+        return Objects.hash(name, phone, email, address, tags, attendances, assignments);
     }
 }

--- a/src/main/java/seedu/studmap/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/studmap/model/util/SampleDataUtil.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import seedu.studmap.model.ReadOnlyStudMap;
 import seedu.studmap.model.StudMap;
 import seedu.studmap.model.student.Address;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Email;
 import seedu.studmap.model.student.Name;
@@ -41,6 +42,9 @@ public class SampleDataUtil {
         studentData.setEmail(new Email("berniceyu@example.com"));
         studentData.setAddress(new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"));
         studentData.setTags(getTagSet("colleagues", "friends"));
+        studentData.setAssignments(getMarkedAssignments("A01", "A02"));
+        studentData.addAssignments(getReceivedAssignments("A03", "A04"));
+        studentData.addAssignments(getNewAssignments("A05", "A06"));
         studentDatas.add(studentData);
 
         studentData = new StudentData();
@@ -112,6 +116,33 @@ public class SampleDataUtil {
     public static Set<Attendance> getNotAttendedSet(String... strings) {
         return Arrays.stream(strings)
                 .map(className -> new Attendance(className, Boolean.FALSE))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a set of unmarked assignments containing the list of strings.
+     */
+    public static Set<Assignment> getNewAssignments(String... strings) {
+        return Arrays.stream(strings)
+                .map(assignmentName -> new Assignment(assignmentName, Assignment.Status.NEW))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a set of received assignments containing the list of strings.
+     */
+    public static Set<Assignment> getReceivedAssignments(String... strings) {
+        return Arrays.stream(strings)
+                .map(assignmentName -> new Assignment(assignmentName, Assignment.Status.RECEIVED))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a set of marked assignments containing the list of strings.
+     */
+    public static Set<Assignment> getMarkedAssignments(String... strings) {
+        return Arrays.stream(strings)
+                .map(assignmentName -> new Assignment(assignmentName, Assignment.Status.MARKED))
                 .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedAssignment.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedAssignment.java
@@ -1,0 +1,51 @@
+package seedu.studmap.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.studmap.commons.exceptions.IllegalValueException;
+import seedu.studmap.model.student.Assignment;
+
+/**
+ * Jackson-friendly version of {@link Assignment}.
+ */
+class JsonAdaptedAssignment {
+
+    private final String assignmentName;
+
+    /**
+     * Constructs a {@code JsonAdaptedAssignment} with the given {@code assignmentName}.
+     */
+    @JsonCreator
+    public JsonAdaptedAssignment(String assignmentName) {
+        this.assignmentName = assignmentName;
+    }
+
+    /**
+     * Converts a given {@code Assignment} into this class for Jackson use.
+     */
+    public JsonAdaptedAssignment(Assignment source) {
+        assignmentName = source.getString();
+    }
+
+    @JsonValue
+    public String getAssignmentName() {
+        return assignmentName;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted Assignment object into the model's {@code Assignment} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted Assignment.
+     */
+    public Assignment toModelType() throws IllegalValueException {
+        String[] values = assignmentName.split(":");
+        if (values.length != 2
+                || !Assignment.isValidAssignmentName(values[0])) {
+            throw new IllegalValueException(Assignment.MESSAGE_CONSTRAINTS);
+        }
+        Assignment.Status markingStatus = Assignment.stringToStatus(values[1]);
+        return new Assignment(values[0], markingStatus);
+    }
+
+}

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedAttendance.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedAttendance.java
@@ -14,7 +14,7 @@ class JsonAdaptedAttendance {
     private final String className;
 
     /**
-     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     * Constructs a {@code JsonAdaptedAttendance} with the given {@code className}.
      */
     @JsonCreator
     public JsonAdaptedAttendance(String className) {
@@ -22,7 +22,7 @@ class JsonAdaptedAttendance {
     }
 
     /**
-     * Converts a given {@code Tag} into this class for Jackson use.
+     * Converts a given {@code Attendance} into this class for Jackson use.
      */
     public JsonAdaptedAttendance(Attendance source) {
         className = source.getString();

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedStudent.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.studmap.commons.exceptions.IllegalValueException;
 import seedu.studmap.model.student.Address;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Email;
 import seedu.studmap.model.student.Name;
@@ -32,6 +33,7 @@ class JsonAdaptedStudent {
     private final String address;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
     private final List<JsonAdaptedAttendance> attended = new ArrayList<>();
+    private final List<JsonAdaptedAssignment> assigned = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedStudent} with the given student details.
@@ -40,7 +42,8 @@ class JsonAdaptedStudent {
     public JsonAdaptedStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                               @JsonProperty("email") String email, @JsonProperty("studmap") String address,
                               @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-                              @JsonProperty("attended") List<JsonAdaptedAttendance> attended) {
+                              @JsonProperty("attended") List<JsonAdaptedAttendance> attended,
+                              @JsonProperty("assignments") List<JsonAdaptedAssignment> assignments) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -50,6 +53,9 @@ class JsonAdaptedStudent {
         }
         if (attended != null) {
             this.attended.addAll(attended);
+        }
+        if (assignments != null) {
+            this.assigned.addAll(assignments);
         }
     }
 
@@ -67,6 +73,9 @@ class JsonAdaptedStudent {
         attended.addAll(source.getAttendances().stream()
                 .map(attendance -> new JsonAdaptedAttendance(attendance.getString()))
                 .collect(Collectors.toList()));
+        assigned.addAll(source.getAssignments().stream()
+                .map(assignment -> new JsonAdaptedAssignment(assignment.getString()))
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -83,6 +92,11 @@ class JsonAdaptedStudent {
         final List<Attendance> studentAttendances = new ArrayList<>();
         for (JsonAdaptedAttendance attendance : attended) {
             studentAttendances.add(attendance.toModelType());
+        }
+
+        final List<Assignment> studentAssignments = new ArrayList<>();
+        for (JsonAdaptedAssignment assignment : assigned) {
+            studentAssignments.add(assignment.toModelType());
         }
 
         if (name == null) {
@@ -119,6 +133,7 @@ class JsonAdaptedStudent {
 
         final Set<Tag> modelTags = new HashSet<>(studentTags);
         final Set<Attendance> modelAttendances = new HashSet<>(studentAttendances);
+        final Set<Assignment> modelAssignments = new HashSet<>(studentAssignments);
 
         StudentData studentData = new StudentData();
         studentData.setName(modelName);
@@ -127,6 +142,7 @@ class JsonAdaptedStudent {
         studentData.setAddress(modelAddress);
         studentData.setTags(modelTags);
         studentData.setAttendances(modelAttendances);
+        studentData.setAssignments(modelAssignments);
         return new Student(studentData);
     }
 

--- a/src/main/java/seedu/studmap/ui/StudentCard.java
+++ b/src/main/java/seedu/studmap/ui/StudentCard.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Student;
 
 /**
@@ -42,6 +43,8 @@ public class StudentCard extends UiPart<Region> {
     private FlowPane tags;
     @FXML
     private FlowPane attendances;
+    @FXML
+    private FlowPane assignments;
 
     /**
      * Creates a {@code StudentCode} with the given {@code Student} and index to display.
@@ -65,6 +68,14 @@ public class StudentCard extends UiPart<Region> {
                     return x;
                 })
                 .forEach(attendance -> attendances.getChildren().add(attendance));
+        student.getAssignments().stream()
+                .sorted(Comparator.comparing(assignment -> assignment.assignmentName))
+                .map(assignment -> {
+                    Label x = new Label(assignment.assignmentName);
+                    x.setId(Assignment.statusToString(assignment.markingStatus));
+                    return x;
+                })
+                .forEach(assignment -> assignments.getChildren().add(assignment));
     }
 
     @Override

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -371,3 +371,29 @@
 #absent {
     -fx-background-color: #FF4444;
 }
+
+#assignments {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#assignments .label {
+    -fx-text-fill: white;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+#marked {
+    -fx-background-color: #447959;
+}
+
+#new {
+    -fx-background-color: #a5344c;
+}
+
+#received {
+    -fx-background-color: #be6805;
+}
+

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -29,6 +29,7 @@
       </HBox>
       <FlowPane fx:id="tags" />
       <FlowPane fx:id="attendances" />
+      <FlowPane fx:id="assignments" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/data/JsonSerializableStudMapTest/typicalStudentsStudMap.json
+++ b/src/test/data/JsonSerializableStudMapTest/typicalStudentsStudMap.json
@@ -18,7 +18,8 @@
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "assigned" : [ "A01:marked", "A02:marked", "A03:received", "A04:new" ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",

--- a/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
@@ -36,7 +36,7 @@ class MarkCommandTest {
 
         Student markedStudent = new StudentBuilder(studentToMark).addAttended("T04").build();
 
-        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS,
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS_ATTENDACE,
                 attendance.getAttendanceString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
@@ -55,7 +55,7 @@ class MarkCommandTest {
 
         Student markedStudent = new StudentBuilder(studentInFilteredList).addAttended("T04").build();
 
-        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS,
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS_ATTENDACE,
                 attendance.getAttendanceString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());

--- a/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.studmap.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.studmap.logic.commands.CommandTestUtil.showStudentAtIndex;
 import static seedu.studmap.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.studmap.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
+import static seedu.studmap.testutil.TypicalIndexes.INDEX_THIRD_STUDENT;
 import static seedu.studmap.testutil.TypicalStudents.getTypicalStudMap;
 
 import java.util.HashSet;
@@ -14,9 +15,11 @@ import org.junit.jupiter.api.Test;
 
 import seedu.studmap.commons.core.Messages;
 import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.model.Model;
 import seedu.studmap.model.ModelManager;
 import seedu.studmap.model.UserPrefs;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Student;
 import seedu.studmap.testutil.StudentBuilder;
@@ -33,13 +36,14 @@ class UnmarkCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Student studentToUnmark = model.getFilteredStudentList().get(INDEX_SECOND_STUDENT.getZeroBased());
         Attendance attendance = new Attendance("T01", true);
-        UnmarkCommand unmarkCommand = new UnmarkCommand(INDEX_SECOND_STUDENT, attendance);
+        UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(INDEX_SECOND_STUDENT),
+                new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 
         Set<Attendance> attendanceSet = new HashSet<>(studentToUnmark.getAttendances());
         attendanceSet.remove(attendance);
         Student unmarkedStudent = new StudentBuilder(studentToUnmark).setAttended(attendanceSet).build();
 
-        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_ATTENDANCE_SUCCESS,
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS,
                 attendance.className, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
@@ -49,18 +53,39 @@ class UnmarkCommandTest {
     }
 
     @Test
+    public void execute_validIndexUnfilteredListAssignment_success() {
+        Student studentToUnmark = model.getFilteredStudentList().get(INDEX_THIRD_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A01", Assignment.Status.NEW);
+        UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(INDEX_THIRD_STUDENT),
+                new UnmarkCommand.UnmarkCommandStudentEditor(assignment));
+
+        Set<Assignment> assignmentSet = new HashSet<>(studentToUnmark.getAssignments());
+        assignmentSet.remove(assignment);
+        Student unmarkedStudent = new StudentBuilder(studentToUnmark).setAssigned(assignmentSet).build();
+
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SINGLE_ASSIGNMENT_SUCCESS,
+                assignment.getAssignmentName(), unmarkedStudent);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        expectedModel.setStudent(model.getFilteredStudentList()
+                .get(INDEX_THIRD_STUDENT.getZeroBased()), unmarkedStudent);
+        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_filteredList_success() {
         showStudentAtIndex(model, INDEX_SECOND_STUDENT);
 
         Student studentInFilteredList = model.getFilteredStudentList().get(0);
         Attendance attendance = new Attendance("T01", true);
-        UnmarkCommand unmarkCommand = new UnmarkCommand(INDEX_FIRST_STUDENT, attendance);
+        UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 
         Set<Attendance> attendanceSet = new HashSet<>(studentInFilteredList.getAttendances());
         attendanceSet.remove(attendance);
         Student unmarkedStudent = new StudentBuilder(studentInFilteredList).setAttended(attendanceSet).build();
 
-        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_ATTENDANCE_SUCCESS,
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS,
                 attendance.className, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
@@ -72,7 +97,8 @@ class UnmarkCommandTest {
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         Attendance attendance = new Attendance("T04", true);
-        UnmarkCommand unmarkCommand = new UnmarkCommand(outOfBoundIndex, attendance);
+        UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(outOfBoundIndex),
+                new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 
         assertCommandFailure(unmarkCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
@@ -39,7 +39,7 @@ class UnmarkCommandTest {
         attendanceSet.remove(attendance);
         Student unmarkedStudent = new StudentBuilder(studentToUnmark).setAttended(attendanceSet).build();
 
-        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SUCCESS,
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_ATTENDANCE_SUCCESS,
                 attendance.className, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
@@ -60,7 +60,7 @@ class UnmarkCommandTest {
         attendanceSet.remove(attendance);
         Student unmarkedStudent = new StudentBuilder(studentInFilteredList).setAttended(attendanceSet).build();
 
-        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SUCCESS,
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_ATTENDANCE_SUCCESS,
                 attendance.className, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());

--- a/src/test/java/seedu/studmap/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/UnmarkCommandParserTest.java
@@ -7,7 +7,9 @@ import static seedu.studmap.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
 import seedu.studmap.logic.commands.UnmarkCommand;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 
 public class UnmarkCommandParserTest {
@@ -15,10 +17,20 @@ public class UnmarkCommandParserTest {
     private UnmarkCommandParser parser = new UnmarkCommandParser();
 
     @Test
-    public void parse_validArgs_returnUnmarkCommand() {
+    public void parse_validArgsAttendance_returnUnmarkCommand() {
         String className = "T01";
-        assertParseSuccess(parser, "1 c/  " + className, new UnmarkCommand(INDEX_FIRST_STUDENT,
-                new Attendance(className, true)));
+        assertParseSuccess(parser, "1 c/   " + className,
+                new UnmarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                        new UnmarkCommand.UnmarkCommandStudentEditor(new Attendance(className, true))));
+    }
+
+    @Test
+    public void parse_validArgsAssignment_returnUnmarkCommand() {
+        String className = "A01";
+        assertParseSuccess(parser, "1 a/   " + className,
+                new UnmarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                        new UnmarkCommand.UnmarkCommandStudentEditor(
+                                new Assignment(className, Assignment.Status.NEW))));
     }
 
     @Test

--- a/src/test/java/seedu/studmap/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/studmap/storage/JsonAdaptedStudentTest.java
@@ -35,6 +35,9 @@ public class JsonAdaptedStudentTest {
     private static final List<JsonAdaptedAttendance> VALID_ATTENDANCES = BENSON.getAttendances().stream()
             .map(JsonAdaptedAttendance::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedAssignment> VALID_ASSIGNMENTS = BENSON.getAssignments().stream()
+            .map(JsonAdaptedAssignment::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validstudentDetails_returnsstudent() throws Exception {
@@ -46,7 +49,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                        VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -54,7 +57,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -63,7 +66,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                        VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -71,7 +74,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -80,7 +83,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL,
-                        VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                        VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -88,7 +91,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null,
-                VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                VALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -97,7 +100,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        INVALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES);
+                        INVALID_ADDRESS, VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -105,7 +108,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TAGS, VALID_ATTENDANCES);
+                VALID_TAGS, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -116,7 +119,7 @@ public class JsonAdaptedStudentTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, invalidTags, VALID_ATTENDANCES);
+                        VALID_ADDRESS, invalidTags, VALID_ATTENDANCES, VALID_ASSIGNMENTS);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 
@@ -126,7 +129,7 @@ public class JsonAdaptedStudentTest {
         invalidAttendances.add(new JsonAdaptedAttendance(INVALID_CLASS + ":Present"));
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_TAGS, invalidAttendances);
+                        VALID_ADDRESS, VALID_TAGS, invalidAttendances, VALID_ASSIGNMENTS);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 }

--- a/src/test/java/seedu/studmap/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/studmap/testutil/StudentBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.studmap.model.student.Address;
+import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Attendance;
 import seedu.studmap.model.student.Email;
 import seedu.studmap.model.student.Name;
@@ -29,6 +30,7 @@ public class StudentBuilder {
     private Address address;
     private Set<Tag> tags;
     private Set<Attendance> attendances;
+    private Set<Assignment> assignments;
 
     /**
      * Creates a {@code StudentBuilder} with the default details.
@@ -40,6 +42,7 @@ public class StudentBuilder {
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
         attendances = new HashSet<>();
+        assignments = new HashSet<>();
     }
 
     /**
@@ -52,6 +55,7 @@ public class StudentBuilder {
         address = studentToCopy.getAddress();
         tags = new HashSet<>(studentToCopy.getTags());
         attendances = new HashSet<>(studentToCopy.getAttendances());
+        assignments = new HashSet<>(studentToCopy.getAssignments());
     }
 
     /**
@@ -71,7 +75,7 @@ public class StudentBuilder {
     }
 
     /**
-     * Parses the {@code classNames} which the user has attended into a
+     * Parses the {@code classNames} which the student has attended into a
      * {@code Set<Attendance>} and adds it to the {@code Student} that we are building.
      */
     public StudentBuilder addAttended(String ... classNames) {
@@ -80,7 +84,7 @@ public class StudentBuilder {
     }
 
     /**
-     * Parses the {@code classNames} which the user has attended into a
+     * Parses the {@code classNames} which the student has attended into a
      * {@code Set<Attendance>} and adds it to the {@code Student} that we are building.
      */
     public StudentBuilder addNotAttended(String ... classNames) {
@@ -88,8 +92,40 @@ public class StudentBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code assignmentNames} which the user has not marked into a
+     * {@code Set<Assignment>} and adds it to the {@code Student} that we are building.
+     */
+    public StudentBuilder addAssignedNew(String ... assignmentNames) {
+        this.assignments.addAll(SampleDataUtil.getNewAssignments(assignmentNames));
+        return this;
+    }
+
+    /**
+     * Parses the {@code assignmentNames} which the user has received into a
+     * {@code Set<Assignment>} and adds it to the {@code Student} that we are building.
+     */
+    public StudentBuilder addAssignedReceived(String ... assignmentNames) {
+        this.assignments.addAll(SampleDataUtil.getReceivedAssignments(assignmentNames));
+        return this;
+    }
+
+    /**
+     * Parses the {@code assignmentNames} which the user has marked into a
+     * {@code Set<Assignment>} and adds it to the {@code Student} that we are building.
+     */
+    public StudentBuilder addAssignedMarked(String ... assignmentNames) {
+        this.assignments.addAll(SampleDataUtil.getMarkedAssignments(assignmentNames));
+        return this;
+    }
+
     public StudentBuilder setAttended(Set<Attendance> attendances) {
         this.attendances = attendances;
+        return this;
+    }
+
+    public StudentBuilder setAssigned(Set<Assignment> assignments) {
+        this.assignments = assignments;
         return this;
     }
 
@@ -129,6 +165,7 @@ public class StudentBuilder {
         studentData.setAddress(this.address);
         studentData.setTags(this.tags);
         studentData.setAttendances(this.attendances);
+        studentData.setAssignments(this.assignments);
         return new Student(studentData);
     }
 

--- a/src/test/java/seedu/studmap/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/studmap/testutil/TypicalStudents.java
@@ -34,7 +34,10 @@ public class TypicalStudents {
             .addAttended("T01", "T02")
             .addNotAttended("T03").build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street")
+            .addAssignedMarked("A01", "A02")
+            .addAssignedReceived("A03")
+            .addAssignedNew("A04").build();
     public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withPhone("9482224")


### PR DESCRIPTION
Resolve #57 Resolve #69
## Assignments feature
- Add `Assignment` class to represents the assignments for the student.
- Similar to the `Attendance` class, new `Assignment` is added to a student using the `mark` command with `a/` prefix.
  -  Support3 states: `new` (red), `received` (orange), `marked` (green)
  - Example :`mark 1 new a/ A01` or `mark 1 marked a/ A01`
  - The prefix `a/` is shared with the address and attribute but they will not be used simultaneously so it is unlikely to cause any problem (I hope)
-Adapted  `unmark` to also support removing assignments

## Other changes
- Changed `mark` command to allow override, i.e. doing `mark 1 present c/T01` after `mark 1 absent c/T01` will change the attendance. (I don't know if the original behavior was intentional or changed due to porting to EditCommand)
- Port `UnmarkCommand`  to use `EditStudentCommand`.