### PR TITLE
Remove overzealous input validation for StudentID

### DIFF
--- a/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
@@ -120,9 +120,6 @@ public class ParserUtil {
     public static StudentID parseId(String id) throws ParseException {
         requireNonNull(id);
         String trimmedId = id.trim();
-        if (!StudentID.isValidStudentID(trimmedId)) {
-            throw new ParseException(StudentID.MESSAGE_CONSTRAINTS);
-        }
         return new StudentID(trimmedId);
     }
 

--- a/src/main/java/seedu/studmap/model/student/StudentID.java
+++ b/src/main/java/seedu/studmap/model/student/StudentID.java
@@ -4,13 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Represents a Student's ID in the student map.
- * Guarantees: immutable; is valid as declared in {@link #isValidStudentID(String)}
+ * Guarantees: immutable
  */
 public class StudentID {
-
-    public static final String MESSAGE_CONSTRAINTS = "Student ID should be in the format EXXXXXXX";
-
-    public static final String VALIDATION_REGEX = "^[E]\\d{7}";
 
     public final String value;
 
@@ -21,15 +17,7 @@ public class StudentID {
      */
     public StudentID(String studentID) {
         requireNonNull(studentID);
-        //checkArgument(isValidStudentID(studentID), MESSAGE_CONSTRAINTS);
         this.value = studentID;
-    }
-
-    /**
-     * Returns true if a given string is a valid student ID.
-     */
-    public static boolean isValidStudentID(String test) {
-        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedStudent.java
@@ -163,9 +163,6 @@ class JsonAdaptedStudent {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     StudentID.class.getSimpleName()));
         }
-        if (!StudentID.isValidStudentID(studentID)) {
-            throw new IllegalValueException(StudentID.MESSAGE_CONSTRAINTS);
-        }
         final StudentID modelId = new StudentID(studentID);
 
         if (gitName == null) {


### PR DESCRIPTION
I don't think the assumptions we make about NUS student IDs are universal enough to be imposed as message constraints. Instead, the user should have some autonomy about how they want to represent Student IDs.

Let's remove the input validation for StudentID and allow the user to use any ID they want for their students.

Resolves #114.