### PR TITLE
Allow more flexible module input

### DIFF
--- a/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/studmap/logic/parser/ParserUtil.java
@@ -104,7 +104,7 @@ public class ParserUtil {
      */
     public static Module parseModule(String module) throws ParseException {
         requireNonNull(module);
-        String trimmedModule = module.trim();
+        String trimmedModule = module.trim().toUpperCase();
         if (!Module.isValidModule(trimmedModule)) {
             throw new ParseException(Module.MESSAGE_CONSTRAINTS);
         }


### PR DESCRIPTION
- Make `ParserUtil::parseModule` convert input module string to uppercase to allow more flexible input. Resolves #113.