### PR TITLE
Loosen student name input verification

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -30,7 +30,7 @@ tasks done faster than traditional GUI apps.
 
     * **`list`** : Lists all students.
 
-    * **`add`**`n/John Doe m/CS2103T s/E1234567` : <br> Adds a student
+    * **`add`**`n/John Doe m/CS2103T id/E1234567` : <br> Adds a student
       named `John Doe` to the StudMap.
 
     * **`delete`**`3` : Deletes the 3rd student shown in the current list.
@@ -84,7 +84,7 @@ Format: `help`
 
 Adds a student to the StudMap.
 
-Format: `add n/NAME m/MODULE s/ID [p/PHONE] [e/EMAIL] [g/GITNAME] [h/HANDLE] [t/TAG]…​`
+Format: `add n/NAME m/MODULE id/ID [p/PHONE] [e/EMAIL] [g/GITNAME] [h/HANDLE] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: <b>Tip:</b>
 A student can have any number of tags (including 0)
@@ -92,9 +92,9 @@ A student can have any number of tags (including 0)
 
 Examples:
 
-* `add n/John Doe m/CS2103T s/E1234567`
-* `add n/Betsy Crowe t/PotentialTA e/betsycrowe@example.com s/E3141592 m/CS2101 p/1234567`
-* `add n/Silos Yao t/StrongStudent g/silosyao s/E1234567 m/MA5203`
+* `add n/John Doe m/CS2103T id/E1234567`
+* `add n/Betsy Crowe t/PotentialTA e/betsycrowe@example.com id/E3141592 m/CS2101 p/1234567`
+* `add n/Silos Yao t/StrongStudent g/silosyao id/E1234567 m/MA5203`
 
 ### Listing all students : `list`
 
@@ -106,7 +106,7 @@ Format: `list`
 
 Edits an existing student in the StudMap.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MODULE] [s/ID] [g/GITNAME] [h/TELEHANDLE] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MODULE] [id/ID] [g/GITNAME] [h/TELEHANDLE] [t/TAG]…​`
 
 * Edits the student at the specified `INDEX`. The index refers to the index number shown in the displayed student list.
   The index **must be a positive integer** 1, 2, 3, …​ or use `all` to edit all students currently displayed.
@@ -430,10 +430,10 @@ the data of your previous StudMap home folder.
 
 Action | Format, Examples
 -------|------------------
-**[Add](#adding-a-student-add)** | `add n/NAME m/MODULE s/ID [p/PHONE] [e/EMAIL] [g/GITNAME] [h/HANDLE] [t/TAG]…​` <br> e.g., `add n/John Doe p/98765432 e/johnd@example.com m/CS2103T s/E1234567 g/user1 h/@user1 t/friends t/owesMoney`
+**[Add](#adding-a-student-add)** | `add n/NAME m/MODULE id/ID [p/PHONE] [e/EMAIL] [g/GITNAME] [h/HANDLE] [t/TAG]…​` <br> e.g., `add n/John Doe p/98765432 e/johnd@example.com m/CS2103T id/E1234567 g/user1 h/@user1 t/friends t/owesMoney`
 **[Clear](#clearing-all-entries--clear)** | `clear`
 **[Delete](#deleting-a-student--delete)** | `delete INDEX`<br> e.g., `delete 3`
-**[Edit](#editing-a-student--edit)** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MODULE] [s/ID] [g/GITNAME] [h/TELEHANDLE] [t/TAG]…​` <br> e.g.,`edit 1 p/91234567 e/johndoe@example.com`
+**[Edit](#editing-a-student--edit)** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MODULE] [id/ID] [g/GITNAME] [h/TELEHANDLE] [t/TAG]…​` <br> e.g.,`edit 1 p/91234567 e/johndoe@example.com`
 **[Find](#locating-students-by-name-find)** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **[List](#listing-all-students--list)** | `list`
 **[Help](#viewing-help--help)** | `help`

--- a/src/main/java/seedu/studmap/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/studmap/logic/parser/CliSyntax.java
@@ -10,7 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
-    public static final Prefix PREFIX_ID = new Prefix("s/");
+    public static final Prefix PREFIX_ID = new Prefix("id/");
     public static final Prefix PREFIX_GIT = new Prefix("g/");
     public static final Prefix PREFIX_HANDLE = new Prefix("h/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");

--- a/src/main/java/seedu/studmap/model/student/Name.java
+++ b/src/main/java/seedu/studmap/model/student/Name.java
@@ -13,10 +13,10 @@ public class Name {
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
-     * The first character of the studmap must not be a whitespace,
+     * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^\\S[\\S ]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/studmap/model/student/Name.java
+++ b/src/main/java/seedu/studmap/model/student/Name.java
@@ -10,7 +10,7 @@ import static seedu.studmap.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank.";
+            "Names should not contain any illegal whitespace characters and should not be blank.";
 
     /*
      * The first character of the name must not be a whitespace,

--- a/src/main/java/seedu/studmap/model/student/Name.java
+++ b/src/main/java/seedu/studmap/model/student/Name.java
@@ -53,11 +53,16 @@ public class Name {
                : fullName;
     }
 
+    /**
+     * Compares equality to another {@code Name}.
+     * @param other Other {@code Name} to compare.
+     * @return True if full names are equal, ignoring case.
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                && fullName.equalsIgnoreCase(((Name) other).fullName)); // state check
     }
 
     @Override

--- a/src/test/data/JsonStudMapStorageTest/invalidStudentStudMap.json
+++ b/src/test/data/JsonStudMapStorageTest/invalidStudentStudMap.json
@@ -1,6 +1,6 @@
 {
   "students": [ {
-    "name": "Student with invalid name field: Ha!ns Mu@ster",
+    "name": "Student with invalid name field: Ha!\nns Mu@ster",
     "phone": "9482424",
     "email": "hans@example.com",
     "module": "CS2103T",

--- a/src/test/java/seedu/studmap/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/studmap/logic/commands/CommandTestUtil.java
@@ -74,7 +74,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME = "James\n"; // '\n' not allowed in names
+    public static final String INVALID_NAME = "Jame\ns"; // '\n' not allowed in names
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + INVALID_NAME;
     public static final String INVALID_PHONE = "911a"; // 'a' not allowed in phones
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + INVALID_PHONE;

--- a/src/test/java/seedu/studmap/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/studmap/logic/commands/CommandTestUtil.java
@@ -74,7 +74,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "Jam\nes"; // '\n' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags

--- a/src/test/java/seedu/studmap/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/ParserUtilTest.java
@@ -20,7 +20,7 @@ import seedu.studmap.model.student.Phone;
 import seedu.studmap.model.tag.Tag;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R\nchel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";

--- a/src/test/java/seedu/studmap/model/student/NameTest.java
+++ b/src/test/java/seedu/studmap/model/student/NameTest.java
@@ -27,8 +27,6 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,5 +34,7 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Po, the Tato")); // with comma
+        assertTrue(Name.isValidName("To-To the Mato")); // with hyphen
     }
 }

--- a/src/test/java/seedu/studmap/model/student/NameTest.java
+++ b/src/test/java/seedu/studmap/model/student/NameTest.java
@@ -1,6 +1,8 @@
 package seedu.studmap.model.student;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.studmap.testutil.Assert.assertThrows;
 
@@ -36,5 +38,24 @@ public class NameTest {
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
         assertTrue(Name.isValidName("Po, the Tato")); // with comma
         assertTrue(Name.isValidName("To-To the Mato")); // with hyphen
+    }
+
+    @Test
+    public void isSameName() {
+        String testFullName = "Test Full Name";
+        Name testName = new Name(testFullName);
+
+        // null name
+        assertNotEquals(testName, null);
+
+        // spaces skipped
+        assertNotEquals(testName, new Name("TestFullName"));
+
+        // trailing space
+        assertNotEquals(testName, new Name(testFullName + " "));
+
+        // different case
+        assertEquals(testName, new Name(testFullName.toLowerCase()));
+        assertEquals(testName, new Name(testFullName.toUpperCase()));
     }
 }

--- a/src/test/java/seedu/studmap/model/student/StudentTest.java
+++ b/src/test/java/seedu/studmap/model/student/StudentTest.java
@@ -44,9 +44,9 @@ public class StudentTest {
         editedAlice = new StudentBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameStudent(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Student editedBob = new StudentBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameStudent(editedBob));
+        assertTrue(BOB.isSameStudent(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";

--- a/src/test/java/seedu/studmap/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/studmap/storage/JsonAdaptedStudentTest.java
@@ -17,7 +17,7 @@ import seedu.studmap.model.student.Name;
 import seedu.studmap.model.student.Phone;
 
 public class JsonAdaptedStudentTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R\nchel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";


### PR DESCRIPTION
Students with commas, apostrophes, and slashes in their name cannot be used with our app. Let's

- Allow `Name` to take any character except whitespaces (only normal space allowed), resolves #185.
- Rename the prefix for `StudentId` from `s/` to `id/` so that students whose name includes "s/o", which is not uncommon, can be used in our system.
- Change equality condition for `Name` to ignore case, resolves #111.