### PR TITLE
Update StudentCard to show 'Ungraded' instead of 'Unmarked' for consistency

### DIFF
--- a/src/main/java/seedu/studmap/ui/StudentCard.java
+++ b/src/main/java/seedu/studmap/ui/StudentCard.java
@@ -112,7 +112,7 @@ public class StudentCard extends UiPart<Region> {
         TextFlow partTextFlow = new TextFlow(participationRateName, participationRateLabel);
         participationRate.setGraphic(partTextFlow);
 
-        Label assignmentRateName = new Label("Unmarked: ");
+        Label assignmentRateName = new Label("Ungraded: ");
         participationRateName.setId("info");
         Label assignmentRateLabel = new Label(String.format("%d",
                 student.getAssignmentUnmarkedCount()));


### PR DESCRIPTION
We consider this a bug because it impacts day-to-day use by outright misleading the user. Partially addresses #161.