### PR TITLE
Improve command feedback for non-removals

### DIFF
--- a/src/main/java/seedu/studmap/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/studmap/logic/commands/CommandResult.java
@@ -76,4 +76,9 @@ public class CommandResult {
         return Objects.hash(feedbackToUser, showHelp, exit);
     }
 
+    @Override
+    public String toString() {
+        return feedbackToUser;
+    }
+
 }

--- a/src/main/java/seedu/studmap/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditCommand.java
@@ -56,6 +56,8 @@ public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStude
 
     public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited Student: %1$s";
     public static final String MESSAGE_EDIT_MULTIPLE_STUDENTS_SUCCESS = "Edited %1$d students.";
+    public static final String MESSAGE_UNEDITED_STUDENT = "Student not edited: %1$s";
+    public static final String MESSAGE_UNEDITED_MULTIPLE_STUDENTS = "%1$d students not edited.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
     public EditCommand(IndexListGenerator indexListGenerator, EditCommandStudentEditor studentEditor) {
@@ -70,6 +72,16 @@ public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStude
     @Override
     public String getMultiEditSuccessMessage(List<Student> editedStudents) {
         return String.format(MESSAGE_EDIT_MULTIPLE_STUDENTS_SUCCESS, editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        return String.format(MESSAGE_UNEDITED_STUDENT, uneditedStudent);
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        return String.format(MESSAGE_UNEDITED_MULTIPLE_STUDENTS, uneditedStudents.size());
     }
 
     @Override
@@ -239,7 +251,7 @@ public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStude
         }
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
             assert studentToEdit != null;
 
             StudentData studentData = studentToEdit.getStudentData();
@@ -252,7 +264,7 @@ public class EditCommand extends EditStudentCommand<EditCommand.EditCommandStude
             studentData.setTeleHandle(getHandle().orElse(studentToEdit.getTeleHandle()));
             studentData.setTags(getTags().orElse(studentToEdit.getTags()));
 
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), !studentData.equals(studentToEdit.getStudentData()));
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/EditStudentCommand.java
@@ -105,7 +105,7 @@ public abstract class EditStudentCommand<T extends StudentEditor> extends Comman
             commandOutput.append("\n").append(getMultiUneditedMessage(uneditedStudents));
         }
 
-        return new CommandResult(commandOutput.toString());
+        return new CommandResult(commandOutput.toString().trim());
     }
 
     @Override

--- a/src/main/java/seedu/studmap/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/GradeCommand.java
@@ -45,9 +45,9 @@ public class GradeCommand extends EditStudentCommand<GradeCommand.GradeCommandSt
     public String getSingleEditSuccessMessage(Student editedStudent) {
         Assignment assignment = studentEditor.getAssignment();
         return String.format(MESSAGE_GRADE_SINGLE_SUCCESS_ASSIGNMENT,
-                assignment.getAssignmentName(),
+                assignment.getAttributeName(),
                 editedStudent.getName(),
-                assignment.getAssignmentString(),
+                assignment.state,
                 editedStudent);
     }
 
@@ -55,8 +55,8 @@ public class GradeCommand extends EditStudentCommand<GradeCommand.GradeCommandSt
     public String getMultiEditSuccessMessage(List<Student> editedStudents) {
         Assignment assignment = studentEditor.getAssignment();
         return String.format(MESSAGE_GRADE_MULTI_SUCCESS_ASSIGNMENT,
-                assignment.getAssignmentName(),
-                assignment.getAssignmentString(),
+                assignment.getAttributeName(),
+                assignment.state,
                 editedStudents.size());
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/GradeCommand.java
@@ -35,6 +35,11 @@ public class GradeCommand extends EditStudentCommand<GradeCommand.GradeCommandSt
     public static final String MESSAGE_GRADE_MULTI_SUCCESS_ASSIGNMENT =
             "Set assignment %1$s as %2$s for %3$s students: ";
 
+    public static final String MESSAGE_GRADE_SINGLE_UNEDITED_ASSIGNMENT =
+            "Assignment %1$s for student %2$s is already %3$s:" + " \n%4$s";
+    public static final String MESSAGE_GRADE_MULTI_UNEDITED_ASSIGNMENT =
+            "Assignment %1$s are already set as %2$s for %3$s students";
+
     public static final String MESSAGE_NO_EDIT = "Assignment must be provided.";
 
     public GradeCommand(IndexListGenerator indexListGenerator, GradeCommandStudentEditor studentEditor) {
@@ -58,6 +63,25 @@ public class GradeCommand extends EditStudentCommand<GradeCommand.GradeCommandSt
                 assignment.getAttributeName(),
                 assignment.state,
                 editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        Assignment assignment = studentEditor.getAssignment();
+        return String.format(MESSAGE_GRADE_SINGLE_UNEDITED_ASSIGNMENT,
+                assignment.getAttributeName(),
+                uneditedStudent.getName(),
+                assignment.state,
+                uneditedStudent);
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        Assignment assignment = studentEditor.getAssignment();
+        return String.format(MESSAGE_GRADE_MULTI_UNEDITED_ASSIGNMENT,
+                assignment.getAttributeName(),
+                assignment.state,
+                uneditedStudents.size());
     }
 
     @Override
@@ -87,14 +111,19 @@ public class GradeCommand extends EditStudentCommand<GradeCommand.GradeCommandSt
 
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
+
             StudentData studentData = studentToEdit.getStudentData();
             Set<Assignment> newAssignments = new HashSet<>(studentToEdit.getAssignments());
+
+            if (newAssignments.stream().anyMatch(x -> x.strongEquals(assignment))) {
+                return new EditResult(studentToEdit, false);
+            }
+
             newAssignments.remove(assignment);
             newAssignments.add(assignment);
             studentData.setAssignments(newAssignments);
-
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), true);
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/MarkCommand.java
@@ -40,7 +40,7 @@ public class MarkCommand extends EditStudentCommand<MarkCommand.MarkCommandStude
     @Override
     public String getSingleEditSuccessMessage(Student editedStudent) {
         return String.format(MESSAGE_MARK_SINGLE_SUCCESS_ATTENDANCE,
-                studentEditor.getAttendance().getAttendanceString(),
+                studentEditor.getAttendance().getString(),
                 editedStudent);
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/ParticipateCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/ParticipateCommand.java
@@ -43,7 +43,7 @@ public class ParticipateCommand extends EditStudentCommand<ParticipateCommand.Pa
     public String getSingleEditSuccessMessage(Student editedStudent) {
         requireNonNull(studentEditor.getParticipation());
         return String.format(MESSAGE_MARK_SINGLE_SUCCESS_PARTICIPATION,
-                studentEditor.getParticipation().getParticipationString(),
+                studentEditor.getParticipation().getString(),
                 editedStudent);
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/TagCommand.java
@@ -43,6 +43,10 @@ public class TagCommand extends EditStudentCommand<TagCommand.TagCommandStudentE
 
     public static final String MESSAGE_MULTI_ADD_TAGS_SUCCESS = "Added tags %1$s for %2$d students";
 
+    public static final String MESSAGE_SINGLE_UNEDITED = "Tags not added to Student: %1$s";
+
+    public static final String MESSAGE_MULTI_UNEDITED = "Tags not added to %1$d students";
+
     public static final String MESSAGE_TAGS_NOT_ADDED = "At least one tag must be added";
 
     public TagCommand(IndexListGenerator indexListGenerator, TagCommandStudentEditor editor) {
@@ -60,6 +64,18 @@ public class TagCommand extends EditStudentCommand<TagCommand.TagCommandStudentE
         return String.format(MESSAGE_MULTI_ADD_TAGS_SUCCESS,
                 CollectionUtil.collectionToString(studentEditor.tags),
                 editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        return String.format(MESSAGE_SINGLE_UNEDITED,
+                uneditedStudent.getName());
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        return String.format(MESSAGE_MULTI_UNEDITED,
+                uneditedStudents.size());
     }
 
     @Override
@@ -101,15 +117,15 @@ public class TagCommand extends EditStudentCommand<TagCommand.TagCommandStudentE
         }
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
             assert studentToEdit != null;
 
             StudentData studentData = studentToEdit.getStudentData();
             Set<Tag> newTags = studentData.getTags();
-            newTags.addAll(tags);
+            boolean isEdited = newTags.addAll(tags);
             studentData.setTags(newTags);
 
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), isEdited);
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/UngradeCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UngradeCommand.java
@@ -43,7 +43,7 @@ public class UngradeCommand extends EditStudentCommand<UngradeCommand.UngradeCom
     public String getSingleEditSuccessMessage(Student editedStudent) {
         Assignment assignment = studentEditor.getAssignment();
         return String.format(MESSAGE_UNGRADE_SINGLE_ASSIGNMENT_SUCCESS,
-                assignment.getAssignmentName(),
+                assignment.getAttributeName(),
                 editedStudent);
     }
 
@@ -51,7 +51,7 @@ public class UngradeCommand extends EditStudentCommand<UngradeCommand.UngradeCom
     public String getMultiEditSuccessMessage(List<Student> editedStudents) {
         Assignment assignment = studentEditor.getAssignment();
         return String.format(MESSAGE_UNGRADE_MULTI_ASSIGNMENT_SUCCESS,
-                assignment.getAssignmentName(),
+                assignment.getAttributeName(),
                 editedStudents.size());
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/UngradeCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UngradeCommand.java
@@ -31,7 +31,8 @@ public class UngradeCommand extends EditStudentCommand<UngradeCommand.UngradeCom
 
     public static final String MESSAGE_UNGRADE_MULTI_ASSIGNMENT_SUCCESS = "Removed Assignment %1$s from %2$s Students";
 
-    public static final String MESSAGE_UNGRADE_ASSIGNMENT_NOTFOUND = "Assignment %1$s not found in Student: %2$s";
+    public static final String MESSAGE_UNMARK_SINGLE_ASSIGNMENT_UNEDITED = "Assignment %1$s not found in Student: %2$s";
+    public static final String MESSAGE_UNMARK_MULTI_ASSIGNMENT_UNEDITED = "Assignment %1$s not found in %2$s students";
 
     public static final String MESSAGE_NO_EDIT = "Assignment must be provided.";
 
@@ -53,6 +54,22 @@ public class UngradeCommand extends EditStudentCommand<UngradeCommand.UngradeCom
         return String.format(MESSAGE_UNGRADE_MULTI_ASSIGNMENT_SUCCESS,
                 assignment.getAttributeName(),
                 editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        Assignment assignment = studentEditor.getAssignment();
+        return String.format(MESSAGE_UNMARK_SINGLE_ASSIGNMENT_UNEDITED,
+                assignment.getAttributeName(),
+                uneditedStudent);
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        Assignment assignment = studentEditor.getAssignment();
+        return String.format(MESSAGE_UNMARK_MULTI_ASSIGNMENT_UNEDITED,
+                assignment.getAttributeName(),
+                uneditedStudents.size());
     }
 
     @Override
@@ -82,14 +99,14 @@ public class UngradeCommand extends EditStudentCommand<UngradeCommand.UngradeCom
 
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
             StudentData studentData = studentToEdit.getStudentData();
 
             Set<Assignment> newAssignments = new HashSet<>(studentToEdit.getAssignments());
-            newAssignments.remove(assignment);
+            boolean isEdited = newAssignments.remove(assignment);
             studentData.setAssignments(newAssignments);
 
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), isEdited);
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UnmarkCommand.java
@@ -31,7 +31,8 @@ public class UnmarkCommand extends EditStudentCommand<UnmarkCommand.UnmarkComman
 
     public static final String MESSAGE_UNMARK_MULTI_ATTENDANCE_SUCCESS = "Removed Class %1$s from %2$s students";
 
-    public static final String MESSAGE_UNMARK_ATTENDANCE_NOTFOUND = "Class %1$s not found in Student: %2$s";
+    public static final String MESSAGE_UNMARK_SINGLE_ATTENDANCE_UNEDITED = "Class %1$s not found in Student: %2$s";
+    public static final String MESSAGE_UNMARK_MULTI_ATTENDANCE_UNEDITED = "Class %1$s not found in %2$s students";
 
     public static final String MESSAGE_NO_EDIT = "Attendance must be provided.";
 
@@ -51,6 +52,20 @@ public class UnmarkCommand extends EditStudentCommand<UnmarkCommand.UnmarkComman
         return String.format(MESSAGE_UNMARK_MULTI_ATTENDANCE_SUCCESS,
                 studentEditor.getAttendance().identifier,
                 editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        return String.format(MESSAGE_UNMARK_SINGLE_ATTENDANCE_UNEDITED,
+                studentEditor.getAttendance().identifier,
+                uneditedStudent);
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        return String.format(MESSAGE_UNMARK_MULTI_ATTENDANCE_UNEDITED,
+                studentEditor.getAttendance().identifier,
+                uneditedStudents.size());
     }
 
     @Override
@@ -79,14 +94,14 @@ public class UnmarkCommand extends EditStudentCommand<UnmarkCommand.UnmarkComman
         }
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
             StudentData studentData = studentToEdit.getStudentData();
 
             Set<Attendance> newAttendance = new HashSet<>(studentToEdit.getAttendances());
-            newAttendance.remove(attendance);
+            boolean isEdited = newAttendance.remove(attendance);
             studentData.setAttendances(newAttendance);
 
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), isEdited);
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UnmarkCommand.java
@@ -42,14 +42,14 @@ public class UnmarkCommand extends EditStudentCommand<UnmarkCommand.UnmarkComman
     @Override
     public String getSingleEditSuccessMessage(Student editedStudent) {
         return String.format(MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS,
-                studentEditor.getAttendance().className,
+                studentEditor.getAttendance().identifier,
                 editedStudent);
     }
 
     @Override
     public String getMultiEditSuccessMessage(List<Student> editedStudents) {
         return String.format(MESSAGE_UNMARK_MULTI_ATTENDANCE_SUCCESS,
-                studentEditor.getAttendance().className,
+                studentEditor.getAttendance().identifier,
                 editedStudents.size());
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/UnparticipateCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UnparticipateCommand.java
@@ -47,14 +47,14 @@ public class UnparticipateCommand extends EditStudentCommand<UnparticipateComman
     @Override
     public String getSingleEditSuccessMessage(Student editedStudent) {
         return String.format(MESSAGE_UNMARK_SINGLE_PARTICIPATION_SUCCESS,
-                studentEditor.getParticipation().participationComponent,
+                studentEditor.getParticipation().identifier,
                 editedStudent);
     }
 
     @Override
     public String getMultiEditSuccessMessage(List<Student> editedStudents) {
         return String.format(MESSAGE_UNMARK_MULTI_PARTICIPATION_SUCCESS,
-                studentEditor.getParticipation().participationComponent,
+                studentEditor.getParticipation().identifier,
                 editedStudents.size());
     }
 

--- a/src/main/java/seedu/studmap/logic/commands/UnparticipateCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UnparticipateCommand.java
@@ -34,8 +34,10 @@ public class UnparticipateCommand extends EditStudentCommand<UnparticipateComman
     public static final String MESSAGE_UNMARK_MULTI_PARTICIPATION_SUCCESS = "Removed Participation component %1$s from "
             + "%2$s students";
 
-    public static final String MESSAGE_UNMARK_PARTICIPATION_NOTFOUND = "Participation component %1$s not found in "
-            + "Student: %2$s";
+    public static final String MESSAGE_UNMARK_SINGLE_PARTICIPATION_UNEDITED = "Participation component %1$s not found "
+            + "in Student: %2$s";
+    public static final String MESSAGE_UNMARK_MULTI_PARTICIPATION_UNEDITED = "Participation component %1$s not found "
+            + "in %2$s students";
 
     public static final String MESSAGE_NO_EDIT = "Participation component must be provided.";
 
@@ -56,6 +58,20 @@ public class UnparticipateCommand extends EditStudentCommand<UnparticipateComman
         return String.format(MESSAGE_UNMARK_MULTI_PARTICIPATION_SUCCESS,
                 studentEditor.getParticipation().identifier,
                 editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        return String.format(MESSAGE_UNMARK_SINGLE_PARTICIPATION_UNEDITED,
+                studentEditor.getParticipation().identifier,
+                uneditedStudent);
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        return String.format(MESSAGE_UNMARK_MULTI_PARTICIPATION_UNEDITED,
+                studentEditor.getParticipation().identifier,
+                uneditedStudents.size());
     }
 
     @Override
@@ -84,14 +100,14 @@ public class UnparticipateCommand extends EditStudentCommand<UnparticipateComman
         }
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
             StudentData studentData = studentToEdit.getStudentData();
 
-            Set<Participation> newParticipation = new HashSet<>(studentToEdit.getParticipations());
-            newParticipation.remove(participation);
-            studentData.setParticipations(newParticipation);
+            Set<Participation> newParticipations = new HashSet<>(studentToEdit.getParticipations());
+            boolean isEdited = newParticipations.remove(participation);
+            studentData.setParticipations(newParticipations);
 
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), isEdited);
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/studmap/logic/commands/UntagCommand.java
@@ -44,6 +44,10 @@ public class UntagCommand extends EditStudentCommand<UntagCommand.UntagCommandSt
 
     public static final String MESSAGE_MULTI_DEL_TAGS_SUCCESS = "Deleted tags %1$s for %2$d students";
 
+    public static final String MESSAGE_SINGLE_UNEDITED = "Tags %1$s not found on Student: %2$s";
+
+    public static final String MESSAGE_MULTI_UNEDITED = "Tags %1$s not found on %2$d students";
+
     public static final String MESSAGE_TAGS_NOT_DELETED = "At least one tag must be deleted";
 
     public UntagCommand(IndexListGenerator indexListGenerator, UntagCommandStudentEditor editor) {
@@ -61,6 +65,19 @@ public class UntagCommand extends EditStudentCommand<UntagCommand.UntagCommandSt
         return String.format(MESSAGE_MULTI_DEL_TAGS_SUCCESS,
                 CollectionUtil.collectionToString(studentEditor.tags),
                 editedStudents.size());
+    }
+
+    @Override
+    public String getSingleUneditedMessage(Student uneditedStudent) {
+        return String.format(MESSAGE_SINGLE_UNEDITED, CollectionUtil.collectionToString(studentEditor.tags),
+                uneditedStudent.getName());
+    }
+
+    @Override
+    public String getMultiUneditedMessage(List<Student> uneditedStudents) {
+        return String.format(MESSAGE_MULTI_UNEDITED,
+                CollectionUtil.collectionToString(studentEditor.tags),
+                uneditedStudents.size());
     }
 
     @Override
@@ -102,15 +119,15 @@ public class UntagCommand extends EditStudentCommand<UntagCommand.UntagCommandSt
         }
 
         @Override
-        public Student editStudent(Student studentToEdit) {
+        public EditResult editStudent(Student studentToEdit) {
             assert studentToEdit != null;
 
             StudentData studentData = studentToEdit.getStudentData();
             Set<Tag> newTags = studentData.getTags();
-            newTags.removeAll(tags);
+            boolean isEdited = newTags.removeAll(tags);
             studentData.setTags(newTags);
 
-            return new Student(studentData);
+            return new EditResult(new Student(studentData), isEdited);
         }
 
         @Override

--- a/src/main/java/seedu/studmap/logic/commands/commons/StudentEditor.java
+++ b/src/main/java/seedu/studmap/logic/commands/commons/StudentEditor.java
@@ -14,10 +14,29 @@ public interface StudentEditor {
      * @param studentToEdit Student to be edited
      * @return New edited student
      */
-    Student editStudent(Student studentToEdit);
+    EditResult editStudent(Student studentToEdit);
 
     /**
      * Returns true if this editor will make edits when used.
      */
     boolean hasEdits();
+
+    /**
+     * A class that encapsulates the edit result of an editStudent operation.
+     */
+    final class EditResult {
+        public final Student editedStudent;
+        public final boolean isEdited;
+
+        /**
+         * Constructor for EditResult.
+         *
+         * @param editedStudent Student that has been edited.
+         * @param isEdited      Whether there is an edit.
+         */
+        public EditResult(Student editedStudent, boolean isEdited) {
+            this.editedStudent = editedStudent;
+            this.isEdited = isEdited;
+        }
+    }
 }

--- a/src/main/java/seedu/studmap/logic/parser/GradeCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/GradeCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.studmap.logic.parser.CliSyntax.PREFIX_ASSIGNMENT;
 import static seedu.studmap.logic.parser.ParserUtil.separatePreamble;
 
 import seedu.studmap.commons.core.index.IndexListGenerator;
-import seedu.studmap.commons.exceptions.IllegalValueException;
 import seedu.studmap.logic.commands.EditStudentCommand;
 import seedu.studmap.logic.commands.GradeCommand;
 import seedu.studmap.logic.parser.exceptions.ParseException;
@@ -16,8 +15,13 @@ import seedu.studmap.model.student.Assignment;
  */
 public class GradeCommandParser extends EditStudentCommandParser<GradeCommand.GradeCommandStudentEditor> {
 
-    public static final String MESSAGE_INVALID_OPTION = "Option must either be 'new' or "
-            + "'received' or 'marked' for assignment status";
+    public static final String OPTION_ASSIGNMENT_NEW = "new";
+    public static final String OPTION_ASSIGNMENT_RECEIVED = "received";
+    public static final String OPTION_ASSIGNMENT_MARKED = "marked";
+
+    public static final String MESSAGE_INVALID_OPTION = "Option must either be " + OPTION_ASSIGNMENT_NEW + " or "
+            + OPTION_ASSIGNMENT_RECEIVED + " or " + OPTION_ASSIGNMENT_MARKED + " for assignment status";
+
 
     @Override
     public Prefix[] getPrefixes() {
@@ -58,10 +62,15 @@ public class GradeCommandParser extends EditStudentCommandParser<GradeCommand.Gr
 
     }
 
-    private Assignment.Status parseStatus(String status) throws ParseException {
-        try {
-            return Assignment.stringToStatus(status);
-        } catch (IllegalValueException e) {
+    private Assignment.Status parseStatus(String option) throws ParseException {
+        switch (option) {
+        case OPTION_ASSIGNMENT_NEW:
+            return Assignment.Status.NEW;
+        case OPTION_ASSIGNMENT_RECEIVED:
+            return Assignment.Status.RECEIVED;
+        case OPTION_ASSIGNMENT_MARKED:
+            return Assignment.Status.MARKED;
+        default:
             throw new ParseException(MESSAGE_INVALID_OPTION);
         }
     }

--- a/src/main/java/seedu/studmap/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/MarkCommandParser.java
@@ -16,6 +16,8 @@ import seedu.studmap.model.student.Attendance;
 public class MarkCommandParser extends EditStudentCommandParser<MarkCommand.MarkCommandStudentEditor> {
 
     public static final String MESSAGE_INVALID_OPTION = "Option must either be 'present' or 'absent' for attendance";
+    public static final String OPTION_PRESENT = "present";
+    public static final String OPTION_ABSENT = "absent";
 
     @Override
     public Prefix[] getPrefixes() {
@@ -41,7 +43,7 @@ public class MarkCommandParser extends EditStudentCommandParser<MarkCommand.Mark
 
         MarkCommand.MarkCommandStudentEditor editor = null;
 
-        boolean attended = parseOption(preamble[1]);
+        Attendance.Status attended = parseOption(preamble[1]);
 
         if (argMultimap.getValue(PREFIX_CLASS).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageMessage()));
@@ -55,12 +57,13 @@ public class MarkCommandParser extends EditStudentCommandParser<MarkCommand.Mark
 
     }
 
-    private boolean parseOption(String option) throws ParseException {
-        if (option.equals("present")) {
-            return true;
-        } else if (option.equals("absent")) {
-            return false;
-        } else {
+    private Attendance.Status parseOption(String option) throws ParseException {
+        switch (option) {
+        case OPTION_PRESENT:
+            return Attendance.Status.PRESENT;
+        case OPTION_ABSENT:
+            return Attendance.Status.ABSENT;
+        default:
             throw new ParseException(MESSAGE_INVALID_OPTION);
         }
     }

--- a/src/main/java/seedu/studmap/logic/parser/ParticipateCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/ParticipateCommandParser.java
@@ -14,10 +14,13 @@ import seedu.studmap.model.student.Participation;
  * Parses input arguments and creates a new ParticipateCommand object
  */
 public class ParticipateCommandParser extends EditStudentCommandParser
-        <ParticipateCommand.ParticipateCommandStudentEditor> {
+                                                      <ParticipateCommand.ParticipateCommandStudentEditor> {
 
-    public static final String MESSAGE_INVALID_OPTION = "Option must either be 'yes' or 'no' for participation";
 
+    public static final String OPTION_PARTICIPATED = "yes";
+    public static final String OPTION_NOT_PARTICIPATED = "no";
+    public static final String MESSAGE_INVALID_OPTION =
+            "Option must either be " + OPTION_PARTICIPATED + " or " + OPTION_NOT_PARTICIPATED + " for participation";
 
     @Override
     public Prefix[] getPrefixes() {
@@ -43,7 +46,7 @@ public class ParticipateCommandParser extends EditStudentCommandParser
 
         ParticipateCommand.ParticipateCommandStudentEditor editor = null;
 
-        boolean participated = parseOption(preamble[1]);
+        Participation.Status participated = parseOption(preamble[1]);
 
         if (argMultimap.getValue(PREFIX_PARTICIPATION).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageMessage()));
@@ -58,12 +61,13 @@ public class ParticipateCommandParser extends EditStudentCommandParser
 
     }
 
-    private boolean parseOption(String option) throws ParseException {
-        if (option.equals("yes")) {
-            return true;
-        } else if (option.equals("no")) {
-            return false;
-        } else {
+    private Participation.Status parseOption(String option) throws ParseException {
+        switch (option) {
+        case OPTION_PARTICIPATED:
+            return Participation.Status.PARTICIPATED;
+        case OPTION_NOT_PARTICIPATED:
+            return Participation.Status.NOT_PARTICIPATED;
+        default:
             throw new ParseException(MESSAGE_INVALID_OPTION);
         }
     }

--- a/src/main/java/seedu/studmap/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/UnmarkCommandParser.java
@@ -35,7 +35,7 @@ public class UnmarkCommandParser extends EditStudentCommandParser<UnmarkCommand.
         UnmarkCommand.UnmarkCommandStudentEditor editor = null;
 
         String className = ParserUtil.parseClassName(argMultimap.getValue(PREFIX_CLASS).orElse(""));
-        Attendance attendance = new Attendance(className, true);
+        Attendance attendance = new Attendance(className, Attendance.Status.PRESENT);
         editor = new UnmarkCommand.UnmarkCommandStudentEditor(attendance);
 
         return new UnmarkCommand(indexListGenerator, editor);

--- a/src/main/java/seedu/studmap/logic/parser/UnparticipateCommandParser.java
+++ b/src/main/java/seedu/studmap/logic/parser/UnparticipateCommandParser.java
@@ -34,7 +34,7 @@ public class UnparticipateCommandParser extends EditStudentCommandParser<Unparti
 
         String participationComponent = ParserUtil
                 .parseParticipationComponent(argMultimap.getValue(PREFIX_PARTICIPATION).orElse(""));
-        Participation participation = new Participation(participationComponent, true);
+        Participation participation = new Participation(participationComponent, Participation.Status.PARTICIPATED);
         editor = new UnparticipateCommand.UnparticipateCommandStudentEditor(participation);
 
         return new UnparticipateCommand(indexListGenerator, editor);

--- a/src/main/java/seedu/studmap/model/student/Assignment.java
+++ b/src/main/java/seedu/studmap/model/student/Assignment.java
@@ -40,11 +40,6 @@ public class Assignment extends MultiStateAttribute<String, Assignment.Status> {
     }
 
     @Override
-    public boolean isSameAttribute(MultiStateAttribute<String, Status> other) {
-        return other.identifier.equalsIgnoreCase(this.identifier);
-    }
-
-    @Override
     public boolean isValidAttributeIdentifier(String identifier) {
         return isValidAssignmentName(identifier);
     }
@@ -58,7 +53,7 @@ public class Assignment extends MultiStateAttribute<String, Assignment.Status> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Assignment // instanceof handles nulls
-                && identifier.equals(((Assignment) other).identifier)); // state check
+                && identifier.equals(((Assignment) other).identifier)); // identifier check
     }
 
     @Override

--- a/src/main/java/seedu/studmap/model/student/Assignment.java
+++ b/src/main/java/seedu/studmap/model/student/Assignment.java
@@ -1,54 +1,33 @@
 package seedu.studmap.model.student;
 
-import static seedu.studmap.commons.util.AppUtil.checkArgument;
-import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
-
-import seedu.studmap.commons.exceptions.IllegalValueException;
-
 /**
  * Represents an Assignment object in StudMap.
- * Guarantees: immutable; name is valid as declared in {@link #isValidAssignmentName(String)}
+ * Guarantees: immutable; identifier is valid as declared in {@link #isValidAttributeIdentifier(String)} (String)}
  */
-public class Assignment {
+public class Assignment extends MultiStateAttribute<String, Assignment.Status> {
 
     public static final String MESSAGE_CONSTRAINTS = "Assignment names should consist of "
             + "alphanumerics, space, dash and underscore.";
-    public static final String MESSAGE_STATUS_CONSTRAINTS = "Assignment marking status should be one of "
-            + "new, received or marked.";
     public static final String VALIDATION_REGEX = "[\\p{Alnum} \\-_]+";
-    /**
-     * Represents the possible status the assignment can take.
-     */
-    public static enum Status {
-        MARKED,
-        RECEIVED,
-        NEW
-    }
-    public static final String ASSIGNMENT_MARKED = "marked";
-    public static final String ASSIGNMENT_RECEIVED = "received";
-    public static final String ASSIGNMENT_NEW = "new";
+    public static final String ASSIGNMENT_MARKED = "Marked";
+    public static final String ASSIGNMENT_RECEIVED = "Received";
+    public static final String ASSIGNMENT_NEW = "New";
+    public static final String MESSAGE_STATUS_CONSTRAINTS = "Assignment marking status should be one of "
+            + ASSIGNMENT_NEW + ", " + ASSIGNMENT_RECEIVED + " or " + ASSIGNMENT_RECEIVED + ".";
 
-    public final String assignmentName;
-    public final Status markingStatus;
 
     /**
      * Constructs an {@code Assignment} object.
      *
-     * @param assignmentName A valid assignment name.
-     * @param markingStatus A status representing whether the assignment has been marked
+     * @param identifier A valid assignment name.
+     * @param state      A status representing whether the assignment has been marked
      */
-    public Assignment(String assignmentName, Status markingStatus) {
-        requireAllNonNull(assignmentName, markingStatus);
-        checkArgument(isValidAssignmentName(assignmentName), MESSAGE_CONSTRAINTS);
-        this.assignmentName = assignmentName.toUpperCase();
-        this.markingStatus = markingStatus;
+    public Assignment(String identifier, Status state) {
+        super(identifier, state);
     }
 
-    /**
-     * Returns true if a given string is a valid assignment name.
-     */
-    public static boolean isValidAssignmentName(String test) {
-        return test.matches(VALIDATION_REGEX);
+    public static boolean isValidAssignmentName(String assignmentName) {
+        return assignmentName != null && assignmentName.matches(VALIDATION_REGEX);
     }
 
     /**
@@ -60,61 +39,31 @@ public class Assignment {
                 || test.equals(ASSIGNMENT_NEW);
     }
 
-    /**
-     * Converts the status of the assignment to string.
-     */
-    public static String statusToString(Status status) {
-        switch (status) {
-        case MARKED:
-            return ASSIGNMENT_MARKED;
-        case RECEIVED:
-            return ASSIGNMENT_RECEIVED;
-        default:
-            return ASSIGNMENT_NEW;
-        }
+    @Override
+    public boolean isSameAttribute(MultiStateAttribute<String, Status> other) {
+        return other.identifier.equalsIgnoreCase(this.identifier);
     }
 
-    /**
-     * Converts a string to the assignment status.
-     */
-    public static Status stringToStatus(String statusString) throws IllegalValueException {
-        statusString = statusString.toLowerCase();
-        switch (statusString) {
-        case ASSIGNMENT_MARKED:
-            return Status.MARKED;
-        case ASSIGNMENT_RECEIVED:
-            return Status.RECEIVED;
-        case ASSIGNMENT_NEW:
-            return Status.NEW;
-        default:
-            throw new IllegalValueException(MESSAGE_STATUS_CONSTRAINTS);
-        }
+    @Override
+    public boolean isValidAttributeIdentifier(String identifier) {
+        return isValidAssignmentName(identifier);
     }
 
-    public String getString() {
-        return assignmentName + ':' + statusToString(markingStatus);
+    @Override
+    public String getIdentifierConstraintsMessage() {
+        return MESSAGE_CONSTRAINTS;
     }
-
-    public String getAssignmentString() {
-        return statusToString(markingStatus);
-    }
-
-    public String getAssignmentName() {
-        return assignmentName;
-    }
-
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Assignment // instanceof handles nulls
-                && assignmentName.equals(((Assignment) other).assignmentName)); // state check
-                // no check for markingStatus to ensure only one assignment record per assignmentName
+                && identifier.equals(((Assignment) other).identifier)); // state check
     }
 
     @Override
     public int hashCode() {
-        return assignmentName.hashCode();
+        return identifier.hashCode();
     }
 
     /**
@@ -122,6 +71,46 @@ public class Assignment {
      */
     public String toString() {
         return '[' + getString() + ']';
+    }
+
+    /**
+     * Possible states of an Assignment.
+     */
+    public enum Status {
+        MARKED {
+            @Override
+            public String toString() {
+                return ASSIGNMENT_MARKED;
+            }
+        },
+        RECEIVED {
+            @Override
+            public String toString() {
+                return ASSIGNMENT_RECEIVED;
+            }
+        },
+        NEW {
+            @Override
+            public String toString() {
+                return ASSIGNMENT_NEW;
+            }
+        };
+
+        /**
+         * Translates a string value of {@code Status} to an enum value.
+         */
+        public static Status fromString(String value) throws IllegalArgumentException {
+            switch (value) {
+            case ASSIGNMENT_MARKED:
+                return MARKED;
+            case ASSIGNMENT_RECEIVED:
+                return RECEIVED;
+            case ASSIGNMENT_NEW:
+                return NEW;
+            default:
+                throw new IllegalArgumentException(MESSAGE_STATUS_CONSTRAINTS);
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/studmap/model/student/AssignmentContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/studmap/model/student/AssignmentContainsKeywordsPredicate.java
@@ -21,7 +21,7 @@ public class AssignmentContainsKeywordsPredicate implements Predicate<Student> {
         Set<Assignment> assignmentSet = student.getAssignments();
         for (Assignment assignment : assignmentSet) {
             if (keywords.stream().anyMatch(keywords ->
-                    StringUtil.containsWordIgnoreCase(assignment.assignmentName, keywords))) {
+                    StringUtil.containsWordIgnoreCase(assignment.identifier, keywords))) {
                 return true;
             }
         }

--- a/src/main/java/seedu/studmap/model/student/Attendance.java
+++ b/src/main/java/seedu/studmap/model/student/Attendance.java
@@ -1,34 +1,27 @@
 package seedu.studmap.model.student;
 
-import static seedu.studmap.commons.util.AppUtil.checkArgument;
-import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
-
 /**
  * Represents an Attendance object in StudMap.
  * Guarantees: immutable; name is valid as declared in {@link #isValidClassName(String)}
  */
-public class Attendance {
+public class Attendance extends MultiStateAttribute<String, Attendance.Status> {
 
     public static final String MESSAGE_CONSTRAINTS = "Class names should consist of "
             + "alphanumerics, space, dash and underscore.";
+    public static final String MESSAGE_STATUS_CONSTRAINTS = "Option must either be 'present' or 'absent' for "
+            + "attendance";
     public static final String VALIDATION_REGEX = "[\\p{Alnum} \\-_]+";
     public static final String ATTENDANCE_TRUE = "Present";
     public static final String ATTENDANCE_FALSE = "Absent";
 
-    public final String className;
-    public final boolean hasAttended;
-
     /**
      * Constructs an {@code Attendance} object.
      *
-     * @param className A valid class name.
-     * @param hasAttended A boolean representing whether the student has attended or not
+     * @param state       A valid class name.
+     * @param hasAttended Attendance status.
      */
-    public Attendance(String className, Boolean hasAttended) {
-        requireAllNonNull(className, hasAttended);
-        checkArgument(isValidClassName(className), MESSAGE_CONSTRAINTS);
-        this.className = className;
-        this.hasAttended = hasAttended;
+    public Attendance(String state, Status hasAttended) {
+        super(state, hasAttended);
     }
 
     /**
@@ -38,32 +31,63 @@ public class Attendance {
         return test.matches(VALIDATION_REGEX);
     }
 
-    public String getString() {
-        return className + ':' + getAttendanceString();
+    @Override
+    public boolean isSameAttribute(MultiStateAttribute<String, Status> other) {
+        return other.identifier.equalsIgnoreCase(this.identifier);
     }
 
-    public String getAttendanceString() {
-        return (hasAttended ? ATTENDANCE_TRUE : ATTENDANCE_FALSE);
+    @Override
+    public boolean isValidAttributeIdentifier(String identifier) {
+        return isValidClassName(identifier);
+    }
+
+    @Override
+    public String getIdentifierConstraintsMessage() {
+        return MESSAGE_CONSTRAINTS;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Attendance // instanceof handles nulls
-                && className.equals(((Attendance) other).className)); // state check
-                // no check for hasAttended to ensure only one attendance record per className
+                && state.equals(((Attendance) other).state)); // state check
     }
 
     @Override
     public int hashCode() {
-        return className.hashCode();
+        return state.hashCode();
     }
 
     /**
-     * Format state as text for viewing.
+     * Possible states of an Attendance.
      */
-    public String toString() {
-        return '[' + getString() + ']';
+    public enum Status {
+        PRESENT {
+            @Override
+            public String toString() {
+                return ATTENDANCE_TRUE;
+            }
+        },
+        ABSENT {
+            @Override
+            public String toString() {
+                return ATTENDANCE_FALSE;
+            }
+        };
+
+        /**
+         * Translates a string value of {@code Status} to an enum value.
+         */
+        public static Status fromString(String value) throws IllegalArgumentException {
+            switch (value) {
+            case ATTENDANCE_TRUE:
+                return PRESENT;
+            case ATTENDANCE_FALSE:
+                return ABSENT;
+            default:
+                throw new IllegalArgumentException(MESSAGE_STATUS_CONSTRAINTS);
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/studmap/model/student/Attendance.java
+++ b/src/main/java/seedu/studmap/model/student/Attendance.java
@@ -17,11 +17,11 @@ public class Attendance extends MultiStateAttribute<String, Attendance.Status> {
     /**
      * Constructs an {@code Attendance} object.
      *
-     * @param state       A valid class name.
-     * @param hasAttended Attendance status.
+     * @param className A valid class name.
+     * @param status    Attendance status.
      */
-    public Attendance(String state, Status hasAttended) {
-        super(state, hasAttended);
+    public Attendance(String className, Status status) {
+        super(className, status);
     }
 
     /**

--- a/src/main/java/seedu/studmap/model/student/Attendance.java
+++ b/src/main/java/seedu/studmap/model/student/Attendance.java
@@ -32,11 +32,6 @@ public class Attendance extends MultiStateAttribute<String, Attendance.Status> {
     }
 
     @Override
-    public boolean isSameAttribute(MultiStateAttribute<String, Status> other) {
-        return other.identifier.equalsIgnoreCase(this.identifier);
-    }
-
-    @Override
     public boolean isValidAttributeIdentifier(String identifier) {
         return isValidClassName(identifier);
     }
@@ -50,7 +45,7 @@ public class Attendance extends MultiStateAttribute<String, Attendance.Status> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Attendance // instanceof handles nulls
-                && state.equals(((Attendance) other).state)); // state check
+                && identifier.equals(((Attendance) other).identifier)); // identifier check
     }
 
     @Override

--- a/src/main/java/seedu/studmap/model/student/MultiStateAttribute.java
+++ b/src/main/java/seedu/studmap/model/student/MultiStateAttribute.java
@@ -28,8 +28,11 @@ public abstract class MultiStateAttribute<S, T> {
 
     /**
      * Checks equality with another MultiStateAttribute with the same type parameters.
+     * Has additional requirement that the states are equal.
      */
-    public abstract boolean isSameAttribute(MultiStateAttribute<S, T> other);
+    public boolean strongEquals(MultiStateAttribute<S, T> other) {
+        return equals(other) && this.state.equals(other.state);
+    }
 
     /**
      * Checks equality of identifier with another.

--- a/src/main/java/seedu/studmap/model/student/MultiStateAttribute.java
+++ b/src/main/java/seedu/studmap/model/student/MultiStateAttribute.java
@@ -1,0 +1,59 @@
+package seedu.studmap.model.student;
+
+import static seedu.studmap.commons.util.AppUtil.checkArgument;
+import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
+
+/**
+ * Abstract class to generalize the idea of an attribute with an identifier that also bears a state.
+ * Guarantees: Is immutable.
+ * @param <S> Type of the identifier, e.g. String.
+ * @param <T> Type of the state.
+ */
+public abstract class MultiStateAttribute<S, T> {
+
+    public final S identifier;
+    public final T state;
+
+    /**
+     * Constructor for MultiStateAttribute.
+     * @param identifier Identifier for this attribute.
+     * @param state State of this attribute.
+     */
+    public MultiStateAttribute(S identifier, T state) {
+        requireAllNonNull(identifier, state);
+        checkArgument(isValidAttributeIdentifier(identifier), getIdentifierConstraintsMessage());
+        this.identifier = identifier;
+        this.state = state;
+    }
+
+    /**
+     * Checks equality with another MultiStateAttribute with the same type parameters.
+     */
+    public abstract boolean isSameAttribute(MultiStateAttribute<S, T> other);
+
+    /**
+     * Checks equality of identifier with another.
+     */
+    public abstract boolean isValidAttributeIdentifier(S identifier);
+
+    /**
+     * Returns a message that describes the constraints of the identifier.
+     */
+    public abstract String getIdentifierConstraintsMessage();
+
+    public String getString() {
+        return identifier + ":" + state;
+    }
+
+    /**
+     * Returns a human-readable format of the identifier.
+     */
+    public String getAttributeName() {
+        return identifier.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "[" + getString() + "]";
+    }
+}

--- a/src/main/java/seedu/studmap/model/student/Participation.java
+++ b/src/main/java/seedu/studmap/model/student/Participation.java
@@ -32,11 +32,6 @@ public class Participation extends MultiStateAttribute<String, Participation.Sta
     }
 
     @Override
-    public boolean isSameAttribute(MultiStateAttribute<String, Status> other) {
-        return other.identifier.equalsIgnoreCase(this.identifier);
-    }
-
-    @Override
     public boolean isValidAttributeIdentifier(String identifier) {
         return isValidParticipationName(identifier);
     }
@@ -50,7 +45,7 @@ public class Participation extends MultiStateAttribute<String, Participation.Sta
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Participation // instanceof handles nulls
-                && identifier.equals(((Participation) other).identifier)); // state check
+                && identifier.equals(((Participation) other).identifier)); // identifier check
     }
 
     @Override

--- a/src/main/java/seedu/studmap/model/student/Participation.java
+++ b/src/main/java/seedu/studmap/model/student/Participation.java
@@ -1,34 +1,27 @@
 package seedu.studmap.model.student;
 
-import static seedu.studmap.commons.util.AppUtil.checkArgument;
-import static seedu.studmap.commons.util.CollectionUtil.requireAllNonNull;
-
 /**
  * Represents a Participation object in StudMap.
  * Guarantees: immutable; name is valid as declared in {@link #isValidParticipationName(String)}
  */
-public class Participation {
+public class Participation extends MultiStateAttribute<String, Participation.Status> {
 
     public static final String MESSAGE_CONSTRAINTS = "Participation component should consist of "
             + "alphanumerics, space, dash and underscore.";
     public static final String VALIDATION_REGEX = "[\\p{Alnum} \\-_]+";
     public static final String PARTICIPATION_TRUE = "Participated";
     public static final String PARTICIPATION_FALSE = "Did not participate";
-
-    public final String participationComponent;
-    public final boolean hasParticipated;
+    public static final String MESSAGE_STATUS_CONSTRAINTS =
+            "Status must be " + PARTICIPATION_TRUE + " or " + PARTICIPATION_FALSE + ".";
 
     /**
      * Constructs an {@code Participation} object.
      *
-     * @param participationComponent A valid participation component name.
-     * @param hasParticipated A boolean representing whether the student has participated or not
+     * @param identifier A valid participation component name.
+     * @param status     Participation status.
      */
-    public Participation(String participationComponent, Boolean hasParticipated) {
-        requireAllNonNull(participationComponent, hasParticipated);
-        checkArgument(isValidParticipationName(participationComponent), MESSAGE_CONSTRAINTS);
-        this.participationComponent = participationComponent;
-        this.hasParticipated = hasParticipated;
+    public Participation(String identifier, Participation.Status status) {
+        super(identifier, status);
     }
 
     /**
@@ -38,25 +31,31 @@ public class Participation {
         return test.matches(VALIDATION_REGEX);
     }
 
-    public String getString() {
-        return participationComponent + ':' + getParticipationString();
+    @Override
+    public boolean isSameAttribute(MultiStateAttribute<String, Status> other) {
+        return other.identifier.equalsIgnoreCase(this.identifier);
     }
 
-    public String getParticipationString() {
-        return (hasParticipated ? PARTICIPATION_TRUE : PARTICIPATION_FALSE);
+    @Override
+    public boolean isValidAttributeIdentifier(String identifier) {
+        return isValidParticipationName(identifier);
+    }
+
+    @Override
+    public String getIdentifierConstraintsMessage() {
+        return MESSAGE_STATUS_CONSTRAINTS;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Participation // instanceof handles nulls
-                && participationComponent.equals(((Participation) other).participationComponent)); // state check
-                // no check for hasParticipated to ensure only one participation record per participationComponent
+                && identifier.equals(((Participation) other).identifier)); // state check
     }
 
     @Override
     public int hashCode() {
-        return participationComponent.hashCode();
+        return identifier.hashCode();
     }
 
     /**
@@ -64,6 +63,38 @@ public class Participation {
      */
     public String toString() {
         return '[' + getString() + ']';
+    }
+
+    /**
+     * Possible states of a Participation.
+     */
+    public enum Status {
+        PARTICIPATED {
+            @Override
+            public String toString() {
+                return PARTICIPATION_TRUE;
+            }
+        },
+        NOT_PARTICIPATED {
+            @Override
+            public String toString() {
+                return PARTICIPATION_FALSE;
+            }
+        };
+
+        /**
+         * Translates a string value of {@code Status} to an enum value.
+         */
+        public static Participation.Status fromString(String value) throws IllegalArgumentException {
+            switch (value) {
+            case PARTICIPATION_TRUE:
+                return PARTICIPATED;
+            case PARTICIPATION_FALSE:
+                return NOT_PARTICIPATED;
+            default:
+                throw new IllegalArgumentException(MESSAGE_STATUS_CONSTRAINTS);
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/studmap/model/student/Student.java
+++ b/src/main/java/seedu/studmap/model/student/Student.java
@@ -38,10 +38,18 @@ public class Student {
      * @param studentData StudentData parameter object.
      */
     public Student(StudentData studentData) {
-        requireAllNonNull(studentData.getId(), studentData.getGitUser(),
-                studentData.getTeleHandle(), studentData.getName(), studentData.getPhone(),
-                studentData.getEmail(), studentData.getModule(), studentData.getTags(),
-                studentData.getAttendances(), studentData.getAssignments(), studentData.getParticipations());
+        requireAllNonNull(
+                studentData.getId(),
+                studentData.getGitUser(),
+                studentData.getTeleHandle(),
+                studentData.getName(),
+                studentData.getPhone(),
+                studentData.getEmail(),
+                studentData.getModule(),
+                studentData.getTags(),
+                studentData.getAttendances(),
+                studentData.getAssignments(),
+                studentData.getParticipations());
 
         this.id = studentData.getId();
         this.module = studentData.getModule();
@@ -197,7 +205,7 @@ public class Student {
      */
     public float getAttendancePercentage() {
         float numOfClasses = getAttendances().size();
-        float presentFor = (float) getAttendances().stream().filter(x -> x.hasAttended).count();
+        float presentFor = (float) getAttendances().stream().filter(x -> x.state == Attendance.Status.PRESENT).count();
         return presentFor / numOfClasses * 100;
     }
 
@@ -209,7 +217,7 @@ public class Student {
         if (numOfClasses == 0) {
             return -Float.MIN_VALUE;
         }
-        float presentFor = (float) getAttendances().stream().filter(x -> x.hasAttended).count();
+        float presentFor = (float) getAttendances().stream().filter(x -> x.state == Attendance.Status.PRESENT).count();
         return presentFor / numOfClasses * 100;
     }
 
@@ -221,7 +229,7 @@ public class Student {
         if (numOfClasses == 0) {
             return Float.MAX_VALUE;
         }
-        float presentFor = (float) getAttendances().stream().filter(x -> x.hasAttended).count();
+        float presentFor = (float) getAttendances().stream().filter(x -> x.state == Attendance.Status.PRESENT).count();
         return presentFor / numOfClasses * 100;
     }
 
@@ -242,7 +250,8 @@ public class Student {
         if (numOfPart == 0) {
             return -Float.MIN_VALUE;
         }
-        float participatedFor = (float) getParticipations().stream().filter(x -> x.hasParticipated).count();
+        float participatedFor =
+                (float) getParticipations().stream().filter(x -> x.state == Participation.Status.PARTICIPATED).count();
         return participatedFor / numOfPart * 100;
     }
 
@@ -254,7 +263,8 @@ public class Student {
         if (numOfPart == 0) {
             return Float.MAX_VALUE;
         }
-        float participatedFor = (float) getParticipations().stream().filter(x -> x.hasParticipated).count();
+        float participatedFor =
+                (float) getParticipations().stream().filter(x -> x.state == Participation.Status.PARTICIPATED).count();
         return participatedFor / numOfPart * 100;
     }
 
@@ -263,7 +273,8 @@ public class Student {
      */
     public float getParticipationPercentage() {
         float numOfPart = getParticipations().size();
-        float participatedFor = (float) getParticipations().stream().filter(x -> x.hasParticipated).count();
+        float participatedFor =
+                (float) getParticipations().stream().filter(x -> x.state == Participation.Status.PARTICIPATED).count();
         return participatedFor / numOfPart * 100;
     }
 
@@ -272,7 +283,7 @@ public class Student {
      */
     public int getAssignmentMarkedCount() {
         return (int) getAssignments().stream()
-                .filter(x -> x.markingStatus == Assignment.Status.MARKED).count();
+                .filter(x -> x.state == Assignment.Status.MARKED).count();
     }
 
     /**
@@ -283,7 +294,7 @@ public class Student {
             return Integer.MIN_VALUE;
         } else {
             return (int) getAssignments().stream()
-                                         .filter(x -> x.markingStatus == Assignment.Status.MARKED).count();
+                    .filter(x -> x.state == Assignment.Status.MARKED).count();
         }
     }
 
@@ -295,7 +306,7 @@ public class Student {
             return Integer.MAX_VALUE;
         } else {
             return (int) getAssignments().stream()
-                                         .filter(x -> x.markingStatus == Assignment.Status.MARKED).count();
+                    .filter(x -> x.state == Assignment.Status.MARKED).count();
         }
     }
 
@@ -304,7 +315,7 @@ public class Student {
      */
     public int getAssignmentUnmarkedCount() {
         return (int) getAssignments().stream()
-                .filter(x -> x.markingStatus == Assignment.Status.RECEIVED).count();
+                .filter(x -> x.state == Assignment.Status.RECEIVED).count();
     }
 
     /**

--- a/src/main/java/seedu/studmap/model/student/StudentData.java
+++ b/src/main/java/seedu/studmap/model/student/StudentData.java
@@ -86,20 +86,8 @@ public class StudentData {
         this.tags = tags;
     }
 
-    public void setAttendances(Set<Attendance> attendances) {
-        this.attendances = attendances;
-    }
-
     public void addAttendances(Set<Attendance> attendances) {
         this.attendances.addAll(attendances);
-    }
-
-    public void setAssignments(Set<Assignment> assignments) {
-        this.assignments = assignments;
-    }
-
-    public void setParticipations(Set<Participation> participations) {
-        this.participations = participations;
     }
 
     public void addParticipations(Set<Participation> participations) {
@@ -114,12 +102,24 @@ public class StudentData {
         return attendances;
     }
 
+    public void setAttendances(Set<Attendance> attendances) {
+        this.attendances = attendances;
+    }
+
     public Set<Assignment> getAssignments() {
         return assignments;
     }
 
+    public void setAssignments(Set<Assignment> assignments) {
+        this.assignments = assignments;
+    }
+
     public Set<Participation> getParticipations() {
         return participations;
+    }
+
+    public void setParticipations(Set<Participation> participations) {
+        this.participations = participations;
     }
 
     @Override
@@ -131,22 +131,33 @@ public class StudentData {
             return false;
         }
         StudentData that = (StudentData) o;
-        return Objects.equals(name, that.name)
-                && Objects.equals(phone, that.phone)
-                && Objects.equals(email, that.email)
-                && Objects.equals(studentID, that.studentID)
-                && Objects.equals(gitName, that.gitName)
-                && Objects.equals(teleHandle, that.teleHandle)
-                && Objects.equals(module, that.module)
-                && Objects.equals(tags, that.tags)
-                && Objects.equals(attendances, that.attendances)
-                && Objects.equals(assignments, that.assignments);
+        return Objects.equals(this.studentID, that.studentID)
+                && Objects.equals(this.gitName, that.gitName)
+                && Objects.equals(this.teleHandle, that.teleHandle)
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.phone, that.phone)
+                && Objects.equals(this.email, that.email)
+                && Objects.equals(this.module, that.module)
+                && Objects.equals(this.tags, that.tags)
+                && Objects.equals(this.attendances, that.attendances)
+                && Objects.equals(this.assignments, that.assignments)
+                && Objects.equals(this.participations, that.participations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, phone, email, studentID, gitName,
-                teleHandle, module, tags, attendances, assignments);
+        return Objects.hash(
+                studentID,
+                gitName,
+                teleHandle,
+                name,
+                phone,
+                email,
+                module,
+                tags,
+                attendances,
+                assignments,
+                participations);
     }
 
 }

--- a/src/main/java/seedu/studmap/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/studmap/model/util/SampleDataUtil.java
@@ -20,6 +20,7 @@ import seedu.studmap.model.student.StudentData;
 import seedu.studmap.model.student.StudentID;
 import seedu.studmap.model.student.TeleHandle;
 import seedu.studmap.model.tag.Tag;
+
 /**
  * Contains utility methods for populating {@code StudMap} with sample data.
  */
@@ -130,7 +131,7 @@ public class SampleDataUtil {
      */
     public static Set<Attendance> getAttendedSet(String... strings) {
         return Arrays.stream(strings)
-                .map(className -> new Attendance(className, Boolean.TRUE))
+                .map(className -> new Attendance(className, Attendance.Status.PRESENT))
                 .collect(Collectors.toSet());
     }
 
@@ -139,7 +140,7 @@ public class SampleDataUtil {
      */
     public static Set<Attendance> getNotAttendedSet(String... strings) {
         return Arrays.stream(strings)
-                .map(className -> new Attendance(className, Boolean.FALSE))
+                .map(className -> new Attendance(className, Attendance.Status.ABSENT))
                 .collect(Collectors.toSet());
     }
 
@@ -148,8 +149,9 @@ public class SampleDataUtil {
      */
     public static Set<Participation> getParticipatedSet(String... strings) {
         return Arrays.stream(strings)
-                     .map(participationComponent -> new Participation(participationComponent, Boolean.TRUE))
-                     .collect(Collectors.toSet());
+                .map(participationComponent -> new Participation(participationComponent,
+                        Participation.Status.PARTICIPATED))
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -157,8 +159,9 @@ public class SampleDataUtil {
      */
     public static Set<Participation> getNotParticipatedSet(String... strings) {
         return Arrays.stream(strings)
-                     .map(participationComponent -> new Participation(participationComponent, Boolean.FALSE))
-                     .collect(Collectors.toSet());
+                .map(participationComponent -> new Participation(participationComponent,
+                        Participation.Status.NOT_PARTICIPATED))
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedAssignment.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedAssignment.java
@@ -38,13 +38,13 @@ class JsonAdaptedAssignment {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted Assignment.
      */
-    public Assignment toModelType() throws IllegalValueException {
+    public Assignment toModelType() throws IllegalArgumentException {
         String[] values = assignmentName.split(":");
         if (values.length != 2
                 || !Assignment.isValidAssignmentName(values[0])) {
-            throw new IllegalValueException(Assignment.MESSAGE_CONSTRAINTS);
+            throw new IllegalArgumentException(Assignment.MESSAGE_CONSTRAINTS);
         }
-        Assignment.Status markingStatus = Assignment.stringToStatus(values[1]);
+        Assignment.Status markingStatus = Assignment.Status.fromString(values[1]);
         return new Assignment(values[0], markingStatus);
     }
 

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedAttendance.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedAttendance.java
@@ -40,16 +40,18 @@ class JsonAdaptedAttendance {
      */
     public Attendance toModelType() throws IllegalValueException {
         String[] values = className.split(":");
-        boolean hasAttended;
+        Attendance.Status status;
         if (values.length != 2 || !Attendance.isValidClassName(values[0])) {
             throw new IllegalValueException(Attendance.MESSAGE_CONSTRAINTS);
         }
-        if (values[1].equals(Attendance.ATTENDANCE_TRUE)) {
-            hasAttended = true;
-        } else {
-            hasAttended = false;
+
+        try {
+            status = Attendance.Status.fromString(values[1]);
+        } catch (IllegalArgumentException iae) {
+            throw new IllegalValueException(iae.getMessage());
         }
-        return new Attendance(values[0], hasAttended);
+
+        return new Attendance(values[0], status);
     }
 
 }

--- a/src/main/java/seedu/studmap/storage/JsonAdaptedParticipation.java
+++ b/src/main/java/seedu/studmap/storage/JsonAdaptedParticipation.java
@@ -40,16 +40,18 @@ class JsonAdaptedParticipation {
      */
     public Participation toModelType() throws IllegalValueException {
         String[] values = participationComponent.split(":");
-        boolean hasParticipated;
+        Participation.Status status;
         if (values.length != 2 || !Participation.isValidParticipationName(values[0])) {
             throw new IllegalValueException(Participation.MESSAGE_CONSTRAINTS);
         }
-        if (values[1].equals(Participation.PARTICIPATION_TRUE)) {
-            hasParticipated = true;
-        } else {
-            hasParticipated = false;
+
+        try {
+            status = Participation.Status.fromString(values[1]);
+        } catch (IllegalArgumentException iae) {
+            throw new IllegalValueException(iae.getMessage());
         }
-        return new Participation(values[0], hasParticipated);
+
+        return new Participation(values[0], status);
     }
 
 }

--- a/src/main/java/seedu/studmap/ui/StudentCard.java
+++ b/src/main/java/seedu/studmap/ui/StudentCard.java
@@ -8,7 +8,6 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.text.TextFlow;
-import seedu.studmap.model.student.Assignment;
 import seedu.studmap.model.student.Student;
 
 /**
@@ -134,29 +133,29 @@ public class StudentCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         student.getAttendances().stream()
-                .sorted(Comparator.comparing(attendance -> attendance.className))
+                .sorted(Comparator.comparing(attendance -> attendance.identifier))
                 .map(attendance -> {
-                    Label x = new Label(attendance.className);
-                    x.setId(attendance.hasAttended ? "present" : "absent");
+                    Label x = new Label(attendance.identifier);
+                    x.setId(attendance.state.toString());
                     return x;
                 })
                 .forEach(attendance -> attendances.getChildren().add(attendance));
         student.getAssignments().stream()
-                .sorted(Comparator.comparing(assignment -> assignment.assignmentName))
+                .sorted(Comparator.comparing(assignment -> assignment.identifier))
                 .map(assignment -> {
-                    Label x = new Label(assignment.assignmentName);
-                    x.setId(Assignment.statusToString(assignment.markingStatus));
+                    Label x = new Label(assignment.identifier);
+                    x.setId(assignment.state.toString());
                     return x;
                 })
                 .forEach(assignment -> assignments.getChildren().add(assignment));
         student.getParticipations().stream()
-               .sorted(Comparator.comparing(participation -> participation.participationComponent))
-               .map(participation -> {
-                   Label x = new Label(participation.participationComponent);
-                   x.setId(participation.hasParticipated ? "participated" : "didNotParticipate");
-                   return x;
-               })
-               .forEach(participation -> participations.getChildren().add(participation));
+                .sorted(Comparator.comparing(participation -> participation.identifier))
+                .map(participation -> {
+                    Label x = new Label(participation.identifier);
+                    x.setId(participation.state.toString());
+                    return x;
+                })
+                .forEach(participation -> participations.getChildren().add(participation));
     }
 
     @Override

--- a/src/main/java/seedu/studmap/ui/StudentCard.java
+++ b/src/main/java/seedu/studmap/ui/StudentCard.java
@@ -8,6 +8,9 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.text.TextFlow;
+import seedu.studmap.model.student.Assignment;
+import seedu.studmap.model.student.Attendance;
+import seedu.studmap.model.student.Participation;
 import seedu.studmap.model.student.Student;
 
 /**
@@ -136,7 +139,7 @@ public class StudentCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(attendance -> attendance.identifier))
                 .map(attendance -> {
                     Label x = new Label(attendance.identifier);
-                    x.setId(attendance.state.toString());
+                    x.setId(attendance.state == Attendance.Status.PRESENT ? "present" : "absent");
                     return x;
                 })
                 .forEach(attendance -> attendances.getChildren().add(attendance));
@@ -144,7 +147,8 @@ public class StudentCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(assignment -> assignment.identifier))
                 .map(assignment -> {
                     Label x = new Label(assignment.identifier);
-                    x.setId(assignment.state.toString());
+                    x.setId(assignment.state == Assignment.Status.NEW ? "new"
+                            : assignment.state == Assignment.Status.RECEIVED ? "received" : "marked");
                     return x;
                 })
                 .forEach(assignment -> assignments.getChildren().add(assignment));
@@ -152,7 +156,8 @@ public class StudentCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(participation -> participation.identifier))
                 .map(participation -> {
                     Label x = new Label(participation.identifier);
-                    x.setId(participation.state.toString());
+                    x.setId(participation.state == Participation.Status.PARTICIPATED ? "participated"
+                            : "didNotParticipate");
                     return x;
                 })
                 .forEach(participation -> participations.getChildren().add(participation));

--- a/src/test/data/JsonSerializableStudMapTest/typicalStudentsStudMap.json
+++ b/src/test/data/JsonSerializableStudMapTest/typicalStudentsStudMap.json
@@ -28,7 +28,7 @@
     "gitName" : "user3",
     "handle" : "@user3",
     "tagged" : [ ],
-    "assigned" : [ "A01:marked", "A02:marked", "A03:received", "A04:new" ]
+    "assigned" : [ "A01:Marked", "A02:Marked", "A03:Received", "A04:New" ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",

--- a/src/test/java/seedu/studmap/logic/commands/GradeCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/GradeCommandTest.java
@@ -1,0 +1,162 @@
+package seedu.studmap.logic.commands;
+
+import static seedu.studmap.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.studmap.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.studmap.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static seedu.studmap.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+import static seedu.studmap.testutil.TypicalStudents.getTypicalStudMap;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.studmap.commons.core.Messages;
+import seedu.studmap.commons.core.index.Index;
+import seedu.studmap.commons.core.index.SingleIndexGenerator;
+import seedu.studmap.model.Model;
+import seedu.studmap.model.ModelManager;
+import seedu.studmap.model.UserPrefs;
+import seedu.studmap.model.student.Assignment;
+import seedu.studmap.model.student.Student;
+import seedu.studmap.testutil.StudentBuilder;
+
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code GradeCommand}.
+ */
+class GradeCommandTest {
+
+    private Model model = new ModelManager(getTypicalStudMap(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Student studentToMark = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A123", Assignment.Status.MARKED);
+        GradeCommand gradeCommand = new GradeCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new GradeCommand.GradeCommandStudentEditor(assignment));
+
+        Student markedStudent = new StudentBuilder(studentToMark)
+                .addAssignedMarked("A123").build();
+
+        String expectedMessage = String.format(GradeCommand.MESSAGE_GRADE_SINGLE_SUCCESS_ASSIGNMENT,
+                assignment.getAttributeName(),
+                markedStudent.getName(),
+                assignment.state,
+                markedStudent);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), markedStudent);
+        assertCommandSuccess(gradeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A123", Assignment.Status.MARKED);
+        GradeCommand gradeCommand = new GradeCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new GradeCommand.GradeCommandStudentEditor(assignment));
+
+        Student markedStudent = new StudentBuilder(studentInFilteredList)
+                .addAssignedMarked("A123").build();
+
+        String expectedMessage = String.format(GradeCommand.MESSAGE_GRADE_SINGLE_SUCCESS_ASSIGNMENT,
+                assignment.getAttributeName(),
+                markedStudent.getName(),
+                assignment.state,
+                markedStudent);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), markedStudent);
+        assertCommandSuccess(gradeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidstudentIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
+        Assignment assignment = new Assignment("A123", Assignment.Status.MARKED);
+        GradeCommand gradeCommand = new GradeCommand(new SingleIndexGenerator(outOfBoundIndex),
+                new GradeCommand.GradeCommandStudentEditor(assignment));
+
+        assertCommandFailure(gradeCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_markedNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A123", Assignment.Status.MARKED);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addAssignments(assignment).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        GradeCommand gradeCommand = new GradeCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new GradeCommand.GradeCommandStudentEditor(assignment));
+        String expectedMessage = String.format(GradeCommand.MESSAGE_GRADE_SINGLE_UNEDITED_ASSIGNMENT,
+                assignment.getAttributeName(),
+                studentToMark.getName(),
+                assignment.state,
+                studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(gradeCommand, model, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    public void execute_newNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A123", Assignment.Status.NEW);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addAssignments(assignment).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        GradeCommand gradeCommand = new GradeCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new GradeCommand.GradeCommandStudentEditor(assignment));
+        String expectedMessage = String.format(GradeCommand.MESSAGE_GRADE_SINGLE_UNEDITED_ASSIGNMENT,
+                assignment.getAttributeName(),
+                studentToMark.getName(),
+                assignment.state,
+                studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(gradeCommand, model, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    public void execute_receivedNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A123", Assignment.Status.RECEIVED);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addAssignments(assignment).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        GradeCommand gradeCommand = new GradeCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new GradeCommand.GradeCommandStudentEditor(assignment));
+        String expectedMessage = String.format(GradeCommand.MESSAGE_GRADE_SINGLE_UNEDITED_ASSIGNMENT,
+                assignment.getAttributeName(),
+                studentToMark.getName(),
+                assignment.state,
+                studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(gradeCommand, model, expectedMessage, expectedModel);
+
+    }
+}

--- a/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
@@ -73,4 +73,50 @@ class MarkCommandTest {
 
         assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
+
+    @Test
+    public void execute_presentNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Attendance attendance = new Attendance("T62", Attendance.Status.PRESENT);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addAttendances(attendance).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new MarkCommand.MarkCommandStudentEditor(attendance));
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_UNEDITED_ATTENDANCE,
+                attendance.getString(), studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    public void execute_absentNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Attendance attendance = new Attendance("T62", Attendance.Status.ABSENT);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addAttendances(attendance).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new MarkCommand.MarkCommandStudentEditor(attendance));
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_UNEDITED_ATTENDANCE,
+                attendance.getString(), studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+
+    }
 }

--- a/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/MarkCommandTest.java
@@ -30,14 +30,14 @@ class MarkCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Student studentToMark = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
-        Attendance attendance = new Attendance("T04", true);
+        Attendance attendance = new Attendance("T04", Attendance.Status.PRESENT);
         MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new MarkCommand.MarkCommandStudentEditor(attendance));
 
         Student markedStudent = new StudentBuilder(studentToMark).addAttended("T04").build();
 
         String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS_ATTENDANCE,
-                attendance.getAttendanceString(), markedStudent);
+                attendance.getString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), markedStudent);
@@ -49,14 +49,14 @@ class MarkCommandTest {
         showStudentAtIndex(model, INDEX_FIRST_STUDENT);
 
         Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
-        Attendance attendance = new Attendance("T04", true);
+        Attendance attendance = new Attendance("T04", Attendance.Status.PRESENT);
         MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new MarkCommand.MarkCommandStudentEditor(attendance));
 
         Student markedStudent = new StudentBuilder(studentInFilteredList).addAttended("T04").build();
 
         String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SINGLE_SUCCESS_ATTENDANCE,
-                attendance.getAttendanceString(), markedStudent);
+                attendance.getString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
@@ -67,7 +67,7 @@ class MarkCommandTest {
     @Test
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        Attendance attendance = new Attendance("T04", true);
+        Attendance attendance = new Attendance("T04", Attendance.Status.PRESENT);
         MarkCommand markCommand = new MarkCommand(new SingleIndexGenerator(outOfBoundIndex),
                 new MarkCommand.MarkCommandStudentEditor(attendance));
 

--- a/src/test/java/seedu/studmap/logic/commands/ParticipateCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/ParticipateCommandTest.java
@@ -34,7 +34,7 @@ class ParticipateCommandTest {
         ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new ParticipateCommand.ParticipateCommandStudentEditor(participation));
 
-        Student markedStudent = new StudentBuilder(studentToMark).addParticipated("P04").build();
+        Student markedStudent = new StudentBuilder(studentToMark).addParticipations("P04").build();
 
         String expectedMessage = String.format(ParticipateCommand.MESSAGE_MARK_SINGLE_SUCCESS_PARTICIPATION,
                 participation.getString(), markedStudent);
@@ -53,7 +53,7 @@ class ParticipateCommandTest {
         ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new ParticipateCommand.ParticipateCommandStudentEditor(participation));
 
-        Student markedStudent = new StudentBuilder(studentInFilteredList).addParticipated("P04").build();
+        Student markedStudent = new StudentBuilder(studentInFilteredList).addParticipations("P04").build();
 
         String expectedMessage = String.format(ParticipateCommand.MESSAGE_MARK_SINGLE_SUCCESS_PARTICIPATION,
                 participation.getString(), markedStudent);
@@ -72,5 +72,51 @@ class ParticipateCommandTest {
                 new ParticipateCommand.ParticipateCommandStudentEditor(participation));
 
         assertCommandFailure(participateCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_participatedNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Participation participation = new Participation("P0123", Participation.Status.PARTICIPATED);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addParticipation(participation).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new ParticipateCommand.ParticipateCommandStudentEditor(participation));
+        String expectedMessage = String.format(ParticipateCommand.MESSAGE_MARK_SINGLE_UNEDITED_PARTICIPATION,
+                participation.getString(), studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(participateCommand, model, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    public void execute_notParticipatedNoEdit_success() {
+
+        // student not edited if already marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Participation participation = new Participation("P0123", Participation.Status.NOT_PARTICIPATED);
+        Student studentToMark = new StudentBuilder(studentInFilteredList).addParticipation(participation).build();
+        model.setStudent(studentInFilteredList, studentToMark);
+
+        ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new ParticipateCommand.ParticipateCommandStudentEditor(participation));
+        String expectedMessage = String.format(ParticipateCommand.MESSAGE_MARK_SINGLE_UNEDITED_PARTICIPATION,
+                participation.getString(), studentToMark);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentToMark);
+        assertCommandSuccess(participateCommand, model, expectedMessage, expectedModel);
+
     }
 }

--- a/src/test/java/seedu/studmap/logic/commands/ParticipateCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/ParticipateCommandTest.java
@@ -30,14 +30,14 @@ class ParticipateCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Student studentToMark = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
-        Participation participation = new Participation("P04", true);
+        Participation participation = new Participation("P04", Participation.Status.PARTICIPATED);
         ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new ParticipateCommand.ParticipateCommandStudentEditor(participation));
 
         Student markedStudent = new StudentBuilder(studentToMark).addParticipated("P04").build();
 
         String expectedMessage = String.format(ParticipateCommand.MESSAGE_MARK_SINGLE_SUCCESS_PARTICIPATION,
-                participation.getParticipationString(), markedStudent);
+                participation.getString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), markedStudent);
@@ -49,14 +49,14 @@ class ParticipateCommandTest {
         showStudentAtIndex(model, INDEX_FIRST_STUDENT);
 
         Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
-        Participation participation = new Participation("P04", true);
+        Participation participation = new Participation("P04", Participation.Status.PARTICIPATED);
         ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new ParticipateCommand.ParticipateCommandStudentEditor(participation));
 
         Student markedStudent = new StudentBuilder(studentInFilteredList).addParticipated("P04").build();
 
         String expectedMessage = String.format(ParticipateCommand.MESSAGE_MARK_SINGLE_SUCCESS_PARTICIPATION,
-                participation.getParticipationString(), markedStudent);
+                participation.getString(), markedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
@@ -67,7 +67,7 @@ class ParticipateCommandTest {
     @Test
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        Participation participation = new Participation("P04", true);
+        Participation participation = new Participation("P04", Participation.Status.PARTICIPATED);
         ParticipateCommand participateCommand = new ParticipateCommand(new SingleIndexGenerator(outOfBoundIndex),
                 new ParticipateCommand.ParticipateCommandStudentEditor(participation));
 

--- a/src/test/java/seedu/studmap/logic/commands/UngradeCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UngradeCommandTest.java
@@ -42,7 +42,7 @@ class UngradeCommandTest {
         Student unmarkedStudent = new StudentBuilder(studentToUnmark).setAssigned(assignmentSet).build();
 
         String expectedMessage = String.format(UngradeCommand.MESSAGE_UNGRADE_SINGLE_ASSIGNMENT_SUCCESS,
-                assignment.getAssignmentName(), unmarkedStudent);
+                assignment.getAttributeName(), unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList()
@@ -64,7 +64,7 @@ class UngradeCommandTest {
         Student unmarkedStudent = new StudentBuilder(studentInFilteredList).setAssigned(assignmentSet).build();
 
         String expectedMessage = String.format(UngradeCommand.MESSAGE_UNGRADE_SINGLE_ASSIGNMENT_SUCCESS,
-                assignment.assignmentName, unmarkedStudent);
+                assignment.identifier, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         showStudentAtIndex(expectedModel, INDEX_THIRD_STUDENT);

--- a/src/test/java/seedu/studmap/logic/commands/UngradeCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UngradeCommandTest.java
@@ -81,4 +81,25 @@ class UngradeCommandTest {
 
         assertCommandFailure(ungradeCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
     }
+
+    @Test
+    public void executeNoEdit_success() {
+
+        // student not edited if not graded
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Assignment assignment = new Assignment("A123", Assignment.Status.NEW);
+
+        UngradeCommand ungradeCommand = new UngradeCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new UngradeCommand.UngradeCommandStudentEditor(assignment));
+        String expectedMessage = String.format(UngradeCommand.MESSAGE_UNMARK_SINGLE_ASSIGNMENT_UNEDITED,
+                assignment.getAttributeName(), studentInFilteredList);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentInFilteredList);
+        assertCommandSuccess(ungradeCommand, model, expectedMessage, expectedModel);
+
+    }
 }

--- a/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
@@ -33,7 +33,7 @@ class UnmarkCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Student studentToUnmark = model.getFilteredStudentList().get(INDEX_SECOND_STUDENT.getZeroBased());
-        Attendance attendance = new Attendance("T01", true);
+        Attendance attendance = new Attendance("T01", Attendance.Status.PRESENT);
         UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(INDEX_SECOND_STUDENT),
                 new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 
@@ -42,7 +42,7 @@ class UnmarkCommandTest {
         Student unmarkedStudent = new StudentBuilder(studentToUnmark).setAttended(attendanceSet).build();
 
         String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS,
-                attendance.className, unmarkedStudent);
+                attendance.identifier, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList()
@@ -56,7 +56,7 @@ class UnmarkCommandTest {
         showStudentAtIndex(model, INDEX_SECOND_STUDENT);
 
         Student studentInFilteredList = model.getFilteredStudentList().get(0);
-        Attendance attendance = new Attendance("T01", true);
+        Attendance attendance = new Attendance("T01", Attendance.Status.PRESENT);
         UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 
@@ -65,7 +65,7 @@ class UnmarkCommandTest {
         Student unmarkedStudent = new StudentBuilder(studentInFilteredList).setAttended(attendanceSet).build();
 
         String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SINGLE_ATTENDANCE_SUCCESS,
-                attendance.className, unmarkedStudent);
+                attendance.identifier, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         showStudentAtIndex(expectedModel, INDEX_SECOND_STUDENT);
@@ -76,7 +76,7 @@ class UnmarkCommandTest {
     @Test
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        Attendance attendance = new Attendance("T04", true);
+        Attendance attendance = new Attendance("T04", Attendance.Status.PRESENT);
         UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(outOfBoundIndex),
                 new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 

--- a/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UnmarkCommandTest.java
@@ -24,7 +24,7 @@ import seedu.studmap.testutil.StudentBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code MarkCommand}.
+ * {@code UnmarkCommand}.
  */
 class UnmarkCommandTest {
 
@@ -81,5 +81,26 @@ class UnmarkCommandTest {
                 new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
 
         assertCommandFailure(unmarkCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void executeNoEdit_success() {
+
+        // student not edited if not marked
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Attendance attendance = new Attendance("T62", Attendance.Status.PRESENT);
+
+        UnmarkCommand unmarkCommand = new UnmarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                new UnmarkCommand.UnmarkCommandStudentEditor(attendance));
+        String expectedMessage = String.format(UnmarkCommand.MESSAGE_UNMARK_SINGLE_ATTENDANCE_UNEDITED,
+                attendance.getAttributeName(), studentInFilteredList);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentInFilteredList);
+        assertCommandSuccess(unmarkCommand, model, expectedMessage, expectedModel);
+
     }
 }

--- a/src/test/java/seedu/studmap/logic/commands/UnparticipateCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UnparticipateCommandTest.java
@@ -33,7 +33,7 @@ class UnparticipateCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Student studentToUnmark = model.getFilteredStudentList().get(INDEX_SECOND_STUDENT.getZeroBased());
-        Participation participation = new Participation("P01", true);
+        Participation participation = new Participation("P01", Participation.Status.PARTICIPATED);
         UnparticipateCommand unparticipateCommand = new UnparticipateCommand(
                 new SingleIndexGenerator(INDEX_SECOND_STUDENT),
                 new UnparticipateCommand.UnparticipateCommandStudentEditor(participation));
@@ -43,7 +43,7 @@ class UnparticipateCommandTest {
         Student unmarkedStudent = new StudentBuilder(studentToUnmark).setParticipated(participationSet).build();
 
         String expectedMessage = String.format(UnparticipateCommand.MESSAGE_UNMARK_SINGLE_PARTICIPATION_SUCCESS,
-                participation.participationComponent, unmarkedStudent);
+                participation.identifier, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList()
@@ -57,7 +57,7 @@ class UnparticipateCommandTest {
         showStudentAtIndex(model, INDEX_SECOND_STUDENT);
 
         Student studentInFilteredList = model.getFilteredStudentList().get(0);
-        Participation participation = new Participation("P01", true);
+        Participation participation = new Participation("P01", Participation.Status.PARTICIPATED);
         UnparticipateCommand unparticipateCommand = new UnparticipateCommand(
                 new SingleIndexGenerator(INDEX_FIRST_STUDENT),
                 new UnparticipateCommand.UnparticipateCommandStudentEditor(participation));
@@ -67,7 +67,7 @@ class UnparticipateCommandTest {
         Student unmarkedStudent = new StudentBuilder(studentInFilteredList).setParticipated(participationSet).build();
 
         String expectedMessage = String.format(UnparticipateCommand.MESSAGE_UNMARK_SINGLE_PARTICIPATION_SUCCESS,
-                participation.participationComponent, unmarkedStudent);
+                participation.identifier, unmarkedStudent);
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         showStudentAtIndex(expectedModel, INDEX_SECOND_STUDENT);
@@ -78,7 +78,7 @@ class UnparticipateCommandTest {
     @Test
     public void execute_invalidstudentIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        Participation participation = new Participation("T04", true);
+        Participation participation = new Participation("T04", Participation.Status.PARTICIPATED);
         UnparticipateCommand unparticipateCommand = new UnparticipateCommand(new SingleIndexGenerator(outOfBoundIndex),
                 new UnparticipateCommand.UnparticipateCommandStudentEditor(participation));
 

--- a/src/test/java/seedu/studmap/logic/commands/UnparticipateCommandTest.java
+++ b/src/test/java/seedu/studmap/logic/commands/UnparticipateCommandTest.java
@@ -47,7 +47,7 @@ class UnparticipateCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList()
-                                      .get(INDEX_SECOND_STUDENT.getZeroBased()), unmarkedStudent);
+                .get(INDEX_SECOND_STUDENT.getZeroBased()), unmarkedStudent);
         assertCommandSuccess(unparticipateCommand, model, expectedMessage, expectedModel);
     }
 
@@ -83,5 +83,27 @@ class UnparticipateCommandTest {
                 new UnparticipateCommand.UnparticipateCommandStudentEditor(participation));
 
         assertCommandFailure(unparticipateCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void executeNoEdit_success() {
+
+        // student not edited if not graded
+
+        showStudentAtIndex(model, INDEX_FIRST_STUDENT);
+        Student studentInFilteredList = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        Participation participation = new Participation("A123", Participation.Status.PARTICIPATED);
+
+        UnparticipateCommand unparticipateCommand =
+                new UnparticipateCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
+                        new UnparticipateCommand.UnparticipateCommandStudentEditor(participation));
+        String expectedMessage = String.format(UnparticipateCommand.MESSAGE_UNMARK_SINGLE_PARTICIPATION_UNEDITED,
+                participation.getAttributeName(), studentInFilteredList);
+
+        ModelManager expectedModel = new ModelManager(model.getStudMap(), new UserPrefs());
+        showStudentAtIndex(expectedModel, INDEX_FIRST_STUDENT);
+        expectedModel.setStudent(model.getFilteredStudentList().get(0), studentInFilteredList);
+        assertCommandSuccess(unparticipateCommand, model, expectedMessage, expectedModel);
+
     }
 }

--- a/src/test/java/seedu/studmap/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/MarkCommandParserTest.java
@@ -21,16 +21,18 @@ public class MarkCommandParserTest {
         String className = "T01";
         assertParseSuccess(parser, "1 absent c/   " + className,
                 new MarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
-                        new MarkCommand.MarkCommandStudentEditor(new Attendance(className, true))));
+                        new MarkCommand.MarkCommandStudentEditor(
+                                new Attendance(className, Attendance.Status.ABSENT))));
     }
 
     @Test
     public void parse_invalidOption_throwsParseException() {
-        assertParseFailure(parser, "1 asd c/ T01", MarkCommandParser.MESSAGE_INVALID_OPTION);
+        assertParseFailure(parser, "1 asd c/ T01", Attendance.MESSAGE_STATUS_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/studmap/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/studmap/logic/parser/UnmarkCommandParserTest.java
@@ -20,7 +20,8 @@ public class UnmarkCommandParserTest {
         String className = "T01";
         assertParseSuccess(parser, "1 c/   " + className,
                 new UnmarkCommand(new SingleIndexGenerator(INDEX_FIRST_STUDENT),
-                        new UnmarkCommand.UnmarkCommandStudentEditor(new Attendance(className, true))));
+                        new UnmarkCommand.UnmarkCommandStudentEditor(new Attendance(className,
+                                Attendance.Status.PRESENT))));
     }
 
     @Test

--- a/src/test/java/seedu/studmap/model/student/AttendanceTest.java
+++ b/src/test/java/seedu/studmap/model/student/AttendanceTest.java
@@ -16,7 +16,7 @@ public class AttendanceTest {
     @Test
     public void constructor_invalidClassName_throwsIllegalArgumentException() {
         String invalidClassName = "!";
-        assertThrows(IllegalArgumentException.class, () -> new Attendance(invalidClassName, Boolean.TRUE));
+        assertThrows(IllegalArgumentException.class, () -> new Attendance(invalidClassName, Attendance.Status.PRESENT));
     }
 
     @Test

--- a/src/test/java/seedu/studmap/model/student/ParticipationTest.java
+++ b/src/test/java/seedu/studmap/model/student/ParticipationTest.java
@@ -16,7 +16,8 @@ public class ParticipationTest {
     @Test
     public void constructor_invalidClassName_throwsIllegalArgumentException() {
         String invalidClassName = "!";
-        assertThrows(IllegalArgumentException.class, () -> new Participation(invalidClassName, Boolean.TRUE));
+        assertThrows(IllegalArgumentException.class, () -> new Participation(invalidClassName,
+                Participation.Status.PARTICIPATED));
     }
 
     @Test

--- a/src/test/java/seedu/studmap/model/student/StudentTest.java
+++ b/src/test/java/seedu/studmap/model/student/StudentTest.java
@@ -107,7 +107,7 @@ public class StudentTest {
         GitName gitName = new GitName(StudentBuilder.DEFAULT_GIT);
         TeleHandle handle = new TeleHandle(StudentBuilder.DEFAULT_TELE);
         Set<Tag> tags = Set.of(new Tag("Friends"));
-        Set<Attendance> attendances = Set.of(new Attendance("T01", true));
+        Set<Attendance> attendances = Set.of(new Attendance("T01", Attendance.Status.PRESENT));
         studentData.setName(name);
         studentData.setPhone(phone);
         studentData.setEmail(email);

--- a/src/test/java/seedu/studmap/model/student/UniqueStudentListTest.java
+++ b/src/test/java/seedu/studmap/model/student/UniqueStudentListTest.java
@@ -59,6 +59,7 @@ public class UniqueStudentListTest {
 
     @Test
     public void setStudent_nullTargetstudent_throwsNullPointerException() {
+        Student test = ALICE;
         assertThrows(NullPointerException.class, () -> uniqueStudentList.setStudent(null, ALICE));
     }
 

--- a/src/test/java/seedu/studmap/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/studmap/testutil/StudentBuilder.java
@@ -103,6 +103,14 @@ public class StudentBuilder {
     }
 
     /**
+     * Adds attendances which the student has.
+     */
+    public StudentBuilder addAttendances(Attendance ... attendances) {
+        this.attendances.addAll(Set.of(attendances));
+        return this;
+    }
+
+    /**
      * Parses the {@code classNames} which the student has attended into a
      * {@code Set<Attendance>} and adds it to the {@code Student} that we are building.
      */
@@ -138,6 +146,14 @@ public class StudentBuilder {
         return this;
     }
 
+    /**
+     * Adds participations which the student has.
+     */
+    public StudentBuilder addAssignments(Assignment ... assignments) {
+        this.assignments.addAll(Set.of(assignments));
+        return this;
+    }
+
     public StudentBuilder setAttended(Set<Attendance> attendances) {
         this.attendances = attendances;
         return this;
@@ -157,7 +173,7 @@ public class StudentBuilder {
      * Parses the {@code participationComponent} which the student has participated into a
      * {@code Set<Participation>} and adds it to the {@code Student} that we are building.
      */
-    public StudentBuilder addParticipated(String ... participationComponent) {
+    public StudentBuilder addParticipations(String ... participationComponent) {
         this.participations.addAll(SampleDataUtil.getParticipatedSet(participationComponent));
         return this;
     }
@@ -168,6 +184,14 @@ public class StudentBuilder {
      */
     public StudentBuilder addNotParticipated(String ... notParticipatedComponent) {
         this.participations.addAll(SampleDataUtil.getNotParticipatedSet(notParticipatedComponent));
+        return this;
+    }
+
+    /**
+     * Adds participations which the student has.
+     */
+    public StudentBuilder addParticipation(Participation ... participations) {
+        this.participations.addAll(Set.of(participations));
         return this;
     }
 

--- a/src/test/java/seedu/studmap/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/studmap/testutil/TypicalStudents.java
@@ -40,7 +40,7 @@ public class TypicalStudents {
             .withTeleHandle("@user2").withTags("owesMoney", "friends")
             .addAttended("T01", "T02")
             .addNotAttended("T03")
-            .addParticipated("P01")
+            .addParticipations("P01")
             .build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withModule("CS2103T")
@@ -51,7 +51,7 @@ public class TypicalStudents {
     public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withModule("CS2103T").withId("E1234564").withGitName("user4")
             .withTeleHandle("@user4").withTags("friends")
-            .addParticipated("P01")
+            .addParticipations("P01")
             .addNotParticipated("P02").build();
     public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withModule("CS2103T").withId("E1234565").withGitName("user5")

--- a/src/test/java/seedu/studmap/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/studmap/testutil/TypicalStudents.java
@@ -32,13 +32,16 @@ public class TypicalStudents {
     public static final Student ALICE = new StudentBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com").withId("E1234561").withGitName("user1")
             .withTeleHandle("@user1").withPhone("94351253").withModule("CS2103T")
-            .withTags("friends").build();
+            .withTags("friends")
+            .build();
     public static final Student BENSON = new StudentBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432").withModule("CS2103T")
             .withId("E1234562").withGitName("user2")
             .withTeleHandle("@user2").withTags("owesMoney", "friends")
             .addAttended("T01", "T02")
-            .addNotAttended("T03").build();
+            .addNotAttended("T03")
+            .addParticipated("P01")
+            .build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withModule("CS2103T")
             .withId("E1234563").withGitName("user3")


### PR DESCRIPTION
- Abstract the idea of a multi-state attribute, such as `Attendance`, `Participation`, `Assignment`, where there is an identifier and value.
- Move the aforementioned 3 classes to inherit from `MultiStateAttribute`.
- Update `Assignment` to follow similar serialization pattern as `Attendance` and `Participation`.
- Removing attendance/participation/assignments that don't exist no longer give a success message
- Add tests for `Grade`, `Ungrade`, `Mark`, `Unmark`, `Participate`, `Unparticipate`.
- Override `toString()` in `CommandResult` for easier testing.

Resolves #130, resolves #131.